### PR TITLE
docs: welcome tar writing contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ reliable).
 None of this is a knock on tar-rs — it is a fine general-purpose library and
 this crate's header parsing draws from it (see acknowledgements). jdx-tar
 exists to own a narrower problem completely: **extracting real-world release
-tarballs, correctly and safely, with good UX hooks**. If you need to *create*
-archives or want an async API, use one of the crates above.
+tarballs, correctly and safely, with good UX hooks**. Archive creation is not
+implemented today, so use one of the crates above if you need it now. A
+well-tested PR adding synchronous, streaming tar writing would be welcome.
 
 ## Features
 
@@ -106,7 +107,8 @@ messages.
 
 ## Non-goals
 
-- **Writing archives** — extraction only.
+- **Writing archives today** — not implemented yet, but contributions are
+  welcome.
 - **Compression codecs** — hand this crate a decompressed `Read`.
 - **Async** — wrap it in `spawn_blocking` if you need to.
 - **Non-tar formats** — no zip, no 7z.


### PR DESCRIPTION
## Summary

- clarify that archive creation is not implemented today
- explicitly welcome a well-tested PR adding synchronous, streaming tar writing
- update the non-goals wording to match

## Impact

Contributors can now see that tar writing is an accepted future direction while users are still directed to existing alternatives for current needs.

## Validation

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or API changes.
> 
> **Overview**
> Updates **README** positioning so “no archive writing” is explicit for users while signaling an accepted contribution path for maintainers.
> 
> In the comparison narrative, it replaces a hard “use other crates for creation” close with wording that **archive creation is not implemented today**, still points readers to alternatives for immediate needs, and **invites well-tested PRs** for synchronous, streaming tar writing.
> 
> The **Non-goals** bullet is aligned: from a flat “extraction only” line to **“Writing archives today”** with a note that contributions are welcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422c0a6db0a63641534acfe54b875b332fcbecfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->