### PR TITLE
feat: add secure per-entry extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ welcome.
   data-extent map is available via `sparse_map()`. Paths are fully resolved
   across long names, PAX overrides, and sparse name un-mangling, so you never
   see `GNUSparseFile.0/...`.
+- Individual entries can be securely extracted with `Entry::unpack_in`, which
+  lets callers inspect or skip entries while retaining the same path and
+  symlink protections as whole-archive extraction.
 - `strip_components` at any depth, applied after name resolution, plus
   `preserve_mtime`, `preserve_permissions`, and `overwrite`.
 - `on_progress` and `on_entry` callbacks. `unpack` returns an `UnpackSummary`

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ welcome.
   data-extent map is available via `sparse_map()`. Paths are fully resolved
   across long names, PAX overrides, and sparse name un-mangling, so you never
   see `GNUSparseFile.0/...`.
-- Individual entries can be securely extracted with `Entry::unpack_in`, which
-  lets callers inspect or skip entries while retaining the same path and
-  symlink protections as whole-archive extraction.
+- `EntryUnpacker` securely extracts selected entries, letting callers inspect
+  or skip entries while retaining the same path, symlink, sparse-file, and
+  deferred-directory-metadata handling as whole-archive extraction.
 - `strip_components` at any depth, applied after name resolution, plus
   `preserve_mtime`, `preserve_permissions`, and `overwrite`.
 - `on_progress` and `on_entry` callbacks. `unpack` returns an `UnpackSummary`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@ use format::{
     push_sparse_pair, trim_metadata, validate_sparse, verify_checksum,
 };
 pub use unpack::{
-    EntryCallback, EntryInfo, Progress, ProgressCallback, SkipReason, SkippedEntry, UnpackOptions,
-    UnpackSummary,
+    EntryCallback, EntryInfo, EntryUnpacker, Progress, ProgressCallback, SkipReason, SkippedEntry,
+    UnpackOptions, UnpackSummary,
 };
-use unpack::{ProgressReporter, unpack_archive, unpack_entry};
+use unpack::{ProgressReporter, unpack_archive};
 
 const BLOCK: u64 = 512;
 const MAX_PAX_SIZE: u64 = 1024 * 1024;
@@ -586,38 +586,6 @@ impl<R: Read> Entry<R> {
     #[must_use]
     pub fn bytes_read(&self) -> u64 {
         self.state.borrow().raw_bytes
-    }
-
-    /// Securely extracts this entry beneath `dest` using default options.
-    ///
-    /// The resolved archive path is validated exactly as it is during
-    /// [`Archive::unpack`]. Absolute paths, traversal, and writes through
-    /// symlinked parents are rejected.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for an unsafe path, malformed link target, truncated
-    /// data, or filesystem extraction failure.
-    pub fn unpack_in<P: AsRef<Path>>(&mut self, dest: P) -> Result<UnpackSummary> {
-        self.unpack_in_with(dest, &mut UnpackOptions::default())
-    }
-
-    /// Securely extracts this entry beneath `dest` using `opts`.
-    ///
-    /// This supports callers that must inspect or skip individual entries,
-    /// such as OCI layer processors handling whiteouts between entries.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error for an unsafe path, malformed link target, truncated
-    /// data, callback-independent I/O failure, or filesystem extraction
-    /// failure.
-    pub fn unpack_in_with<P: AsRef<Path>>(
-        &mut self,
-        dest: P,
-        opts: &mut UnpackOptions,
-    ) -> Result<UnpackSummary> {
-        unpack_entry(self, dest.as_ref(), opts)
     }
 
     fn read_physical(&mut self, buf: &mut [u8]) -> Result<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use unpack::{
     EntryCallback, EntryInfo, Progress, ProgressCallback, SkipReason, SkippedEntry, UnpackOptions,
     UnpackSummary,
 };
-use unpack::{ProgressReporter, unpack_archive};
+use unpack::{ProgressReporter, unpack_archive, unpack_entry};
 
 const BLOCK: u64 = 512;
 const MAX_PAX_SIZE: u64 = 1024 * 1024;
@@ -586,6 +586,38 @@ impl<R: Read> Entry<R> {
     #[must_use]
     pub fn bytes_read(&self) -> u64 {
         self.state.borrow().raw_bytes
+    }
+
+    /// Securely extracts this entry beneath `dest` using default options.
+    ///
+    /// The resolved archive path is validated exactly as it is during
+    /// [`Archive::unpack`]. Absolute paths, traversal, and writes through
+    /// symlinked parents are rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unsafe path, malformed link target, truncated
+    /// data, or filesystem extraction failure.
+    pub fn unpack_in<P: AsRef<Path>>(&mut self, dest: P) -> Result<UnpackSummary> {
+        self.unpack_in_with(dest, &mut UnpackOptions::default())
+    }
+
+    /// Securely extracts this entry beneath `dest` using `opts`.
+    ///
+    /// This supports callers that must inspect or skip individual entries,
+    /// such as OCI layer processors handling whiteouts between entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unsafe path, malformed link target, truncated
+    /// data, callback-independent I/O failure, or filesystem extraction
+    /// failure.
+    pub fn unpack_in_with<P: AsRef<Path>>(
+        &mut self,
+        dest: P,
+        opts: &mut UnpackOptions,
+    ) -> Result<UnpackSummary> {
+        unpack_entry(self, dest.as_ref(), opts)
     }
 
     fn read_physical(&mut self, buf: &mut [u8]) -> Result<usize> {

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -100,6 +100,73 @@ impl Default for UnpackOptions {
     }
 }
 
+/// Stateful secure extractor for callers that inspect or skip individual
+/// entries before unpacking them.
+///
+/// Call [`Self::finish`] after the final entry so directory permissions and
+/// modification times are applied after their children have been written.
+#[must_use = "call finish() to apply deferred directory metadata"]
+pub struct EntryUnpacker<'a> {
+    root: PathBuf,
+    opts: &'a mut UnpackOptions,
+    deferred_dirs: Vec<(PathBuf, u32, i64)>,
+}
+
+impl<'a> EntryUnpacker<'a> {
+    /// Creates a per-entry extractor rooted at `dest`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the destination cannot be created or resolved,
+    /// or when it is itself a symbolic link.
+    pub fn new<P: AsRef<Path>>(dest: P, opts: &'a mut UnpackOptions) -> Result<Self> {
+        let dest = dest.as_ref();
+        fs::create_dir_all(dest)?;
+        if fs::symlink_metadata(dest)?.file_type().is_symlink() {
+            return Err(invalid("destination may not be a symlink"));
+        }
+        Ok(Self {
+            root: fs::canonicalize(dest)?,
+            opts,
+            deferred_dirs: Vec::new(),
+        })
+    }
+
+    /// Securely extracts one entry beneath the configured destination.
+    ///
+    /// Entries may be inspected and omitted by the caller before invoking
+    /// this method. Absolute paths, traversal, and writes through symlinked
+    /// parents are rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unsafe path, malformed link target, truncated
+    /// data, callback-independent I/O failure, or filesystem extraction
+    /// failure.
+    pub fn unpack<R: Read>(&mut self, entry: &mut Entry<R>) -> Result<UnpackSummary> {
+        unpack_entry(entry, &self.root, self.opts, &mut self.deferred_dirs)
+    }
+
+    /// Applies deferred directory metadata and completes extraction.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when directory permissions or modification times
+    /// cannot be restored.
+    pub fn finish(self) -> Result<()> {
+        for (path, mode, mtime) in self.deferred_dirs.into_iter().rev() {
+            apply_metadata(
+                &path,
+                mode,
+                mtime,
+                self.opts.preserve_permissions,
+                self.opts.preserve_mtime,
+            )?;
+        }
+        Ok(())
+    }
+}
+
 pub(super) struct ProgressReporter<'a> {
     callback: &'a mut Option<ProgressCallback>,
     last: u64,
@@ -286,14 +353,10 @@ pub(super) fn unpack_archive<R: Read>(
 #[allow(clippy::too_many_lines)]
 pub(super) fn unpack_entry<R: Read>(
     entry: &mut Entry<R>,
-    dest: &Path,
+    root: &Path,
     opts: &mut UnpackOptions,
+    deferred_dirs: &mut Vec<(PathBuf, u32, i64)>,
 ) -> Result<UnpackSummary> {
-    fs::create_dir_all(dest)?;
-    if fs::symlink_metadata(dest)?.file_type().is_symlink() {
-        return Err(invalid("destination may not be a symlink"));
-    }
-    let root = fs::canonicalize(dest)?;
     let original = entry.path()?.into_owned();
     if let Some(callback) = opts.on_entry.as_mut() {
         callback(&EntryInfo {
@@ -324,20 +387,14 @@ pub(super) fn unpack_entry<R: Read>(
         return Ok(summary);
     }
     let output = root.join(&relative);
-    ensure_safe_parents(&root, &relative)?;
+    ensure_safe_parents(root, &relative)?;
     match entry.kind {
         EntryType::Directory => {
             if output.exists() && fs::symlink_metadata(&output)?.file_type().is_symlink() {
                 return Err(invalid("archive directory collides with symlink"));
             }
             fs::create_dir_all(&output)?;
-            apply_metadata(
-                &output,
-                entry.header.mode,
-                entry.header.mtime,
-                opts.preserve_permissions,
-                opts.preserve_mtime,
-            )?;
+            deferred_dirs.push((output, entry.header.mode, entry.header.mtime));
             summary.dirs = 1;
         }
         EntryType::File => {
@@ -418,7 +475,7 @@ pub(super) fn unpack_entry<R: Read>(
                 .ok_or_else(|| invalid("hardlink lacks target"))?;
             let target_relative = secure_relative_path(&target, opts.strip_components)?
                 .ok_or_else(|| invalid("hardlink target was stripped away"))?;
-            ensure_safe_parents(&root, &target_relative)?;
+            ensure_safe_parents(root, &target_relative)?;
             let source = root.join(target_relative);
             let metadata = fs::symlink_metadata(&source)
                 .map_err(|_| invalid("hardlink target does not exist within destination"))?;

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -1,4 +1,4 @@
-use super::{Archive, EntryType, Result, invalid};
+use super::{Archive, Entry, EntryType, Result, invalid};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
 use std::path::{Component, Path, PathBuf};
@@ -280,6 +280,160 @@ pub(super) fn unpack_archive<R: Read>(
         apply_metadata(&path, mode, mtime, preserve_permissions, preserve_mtime)?;
     }
     progress.boundary(archive.state.borrow().raw_bytes);
+    Ok(summary)
+}
+
+#[allow(clippy::too_many_lines)]
+pub(super) fn unpack_entry<R: Read>(
+    entry: &mut Entry<R>,
+    dest: &Path,
+    opts: &mut UnpackOptions,
+) -> Result<UnpackSummary> {
+    fs::create_dir_all(dest)?;
+    if fs::symlink_metadata(dest)?.file_type().is_symlink() {
+        return Err(invalid("destination may not be a symlink"));
+    }
+    let root = fs::canonicalize(dest)?;
+    let original = entry.path()?.into_owned();
+    if let Some(callback) = opts.on_entry.as_mut() {
+        callback(&EntryInfo {
+            path: original.clone(),
+            entry_type: entry.kind,
+            size: entry.logical_size,
+            sparse: entry.sparse.is_some(),
+        });
+    }
+    let mut summary = UnpackSummary::default();
+    let mut progress = ProgressReporter {
+        callback: &mut opts.on_progress,
+        last: 0,
+    };
+    progress.boundary(entry.bytes_read());
+    let Some(relative) = secure_relative_path(&original, opts.strip_components)? else {
+        summary.skipped.push(SkippedEntry {
+            path: original,
+            reason: SkipReason::Stripped,
+        });
+        return Ok(summary);
+    };
+    if is_reserved_path(&relative) {
+        summary.skipped.push(SkippedEntry {
+            path: original,
+            reason: SkipReason::ReservedName,
+        });
+        return Ok(summary);
+    }
+    let output = root.join(&relative);
+    ensure_safe_parents(&root, &relative)?;
+    match entry.kind {
+        EntryType::Directory => {
+            if output.exists() && fs::symlink_metadata(&output)?.file_type().is_symlink() {
+                return Err(invalid("archive directory collides with symlink"));
+            }
+            fs::create_dir_all(&output)?;
+            apply_metadata(
+                &output,
+                entry.header.mode,
+                entry.header.mtime,
+                opts.preserve_permissions,
+                opts.preserve_mtime,
+            )?;
+            summary.dirs = 1;
+        }
+        EntryType::File => {
+            if !prepare_output(&output, opts.overwrite)? {
+                summary.skipped.push(SkippedEntry {
+                    path: original,
+                    reason: SkipReason::Exists,
+                });
+                return Ok(summary);
+            }
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&output)?;
+            if entry.sparse.is_some() {
+                entry.copy_sparse_to(&mut file, &mut progress)?;
+                summary.sparse_files = 1;
+            } else {
+                let mut buf = vec![0_u8; 64 * 1024];
+                loop {
+                    let n = entry.read(&mut buf)?;
+                    if n == 0 {
+                        break;
+                    }
+                    file.write_all(&buf[..n])?;
+                    progress.update(entry.bytes_read());
+                }
+            }
+            apply_metadata(
+                &output,
+                entry.header.mode,
+                entry.header.mtime,
+                opts.preserve_permissions,
+                opts.preserve_mtime,
+            )?;
+            summary.files = 1;
+        }
+        EntryType::Symlink => {
+            if !prepare_output(&output, opts.overwrite)? {
+                summary.skipped.push(SkippedEntry {
+                    path: original,
+                    reason: SkipReason::Exists,
+                });
+                return Ok(summary);
+            }
+            let target = entry
+                .header
+                .link_name()
+                .ok_or_else(|| invalid("symlink lacks target"))?;
+            match create_symlink(&target, &output) {
+                Ok(()) => summary.symlinks = 1,
+                Err(err)
+                    if cfg!(windows)
+                        && matches!(
+                            err.kind(),
+                            ErrorKind::PermissionDenied | ErrorKind::Unsupported
+                        ) =>
+                {
+                    summary.skipped.push(SkippedEntry {
+                        path: original,
+                        reason: SkipReason::SymlinkUnavailable,
+                    });
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        EntryType::Hardlink => {
+            if !prepare_output(&output, opts.overwrite)? {
+                summary.skipped.push(SkippedEntry {
+                    path: original,
+                    reason: SkipReason::Exists,
+                });
+                return Ok(summary);
+            }
+            let target = entry
+                .header
+                .link_name()
+                .ok_or_else(|| invalid("hardlink lacks target"))?;
+            let target_relative = secure_relative_path(&target, opts.strip_components)?
+                .ok_or_else(|| invalid("hardlink target was stripped away"))?;
+            ensure_safe_parents(&root, &target_relative)?;
+            let source = root.join(target_relative);
+            let metadata = fs::symlink_metadata(&source)
+                .map_err(|_| invalid("hardlink target does not exist within destination"))?;
+            if metadata.file_type().is_symlink() {
+                return Err(invalid("hardlink target may not be a symlink"));
+            }
+            fs::hard_link(source, output)?;
+            summary.hardlinks = 1;
+        }
+        _ => summary.skipped.push(SkippedEntry {
+            path: original,
+            reason: SkipReason::UnsupportedType,
+        }),
+    }
+    progress.boundary(entry.bytes_read());
     Ok(summary)
 }
 

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -100,6 +100,80 @@ fn reads_dense_and_pax_path() {
 }
 
 #[test]
+fn securely_unpacks_selected_entries() {
+    let mut tar = Vec::new();
+    append_entry(&mut tar, header("root/whiteout", 3, b'0'), b"old");
+    append_entry(&mut tar, header("root/tool", 5, b'0'), b"hello");
+    terminate(&mut tar);
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut archive = Archive::new(Cursor::new(tar));
+    let mut entries = archive.entries().unwrap();
+
+    let skipped = entries.next().unwrap().unwrap();
+    assert_eq!(
+        skipped.path().unwrap().as_ref(),
+        std::path::Path::new("root/whiteout")
+    );
+
+    let mut tool = entries.next().unwrap().unwrap();
+    let mut options = UnpackOptions::default();
+    options.strip_components = 1;
+    let summary = tool.unpack_in_with(temp.path(), &mut options).unwrap();
+    assert_eq!(summary.files, 1);
+    assert_eq!(std::fs::read(temp.path().join("tool")).unwrap(), b"hello");
+    assert!(!temp.path().join("whiteout").exists());
+}
+
+#[test]
+fn entry_unpack_handles_sparse_data_and_rejects_traversal() {
+    let mut sparse = Vec::new();
+    let (pax, pax_block) = pax_header(&[
+        ("GNU.sparse.major", "0"),
+        ("GNU.sparse.minor", "1"),
+        ("GNU.sparse.size", "12"),
+        ("GNU.sparse.map", "1,2,9,1"),
+    ]);
+    append_entry(&mut sparse, pax_block, &pax);
+    append_entry(&mut sparse, header("root/sparse", 3, b'0'), b"abc");
+    terminate(&mut sparse);
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut archive = Archive::new(Cursor::new(sparse));
+    let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
+    let summary = entry.unpack_in(temp.path()).unwrap();
+    assert_eq!(summary.files, 1);
+    assert_eq!(summary.sparse_files, 1);
+    assert_eq!(
+        std::fs::read(temp.path().join("root/sparse")).unwrap(),
+        b"\0ab\0\0\0\0\0\0c\0\0"
+    );
+
+    let mut traversal = Vec::new();
+    append_entry(&mut traversal, header("../outside", 1, b'0'), b"x");
+    terminate(&mut traversal);
+    let mut archive = Archive::new(Cursor::new(traversal));
+    let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
+    assert!(entry.unpack_in(temp.path()).is_err());
+}
+
+#[cfg(unix)]
+#[test]
+fn entry_unpack_rejects_symlinked_parent() {
+    let temp = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(outside.path(), temp.path().join("link")).unwrap();
+
+    let mut tar = Vec::new();
+    append_entry(&mut tar, header("link/escape", 1, b'0'), b"x");
+    terminate(&mut tar);
+    let mut archive = Archive::new(Cursor::new(tar));
+    let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
+    assert!(entry.unpack_in(temp.path()).is_err());
+    assert!(!outside.path().join("escape").exists());
+}
+
+#[test]
 fn reads_pax_sparse_1_0_as_logical_content() {
     let mut tar = Vec::new();
     let (pax, pax_block) = pax_header(&[

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,4 +1,4 @@
-use jdx_tar::{Archive, SparseSegment, UnpackOptions};
+use jdx_tar::{Archive, EntryUnpacker, SparseSegment, UnpackOptions};
 #[cfg(unix)]
 use jdx_tar::{EntryType, SkipReason};
 #[cfg(unix)]
@@ -119,7 +119,9 @@ fn securely_unpacks_selected_entries() {
     let mut tool = entries.next().unwrap().unwrap();
     let mut options = UnpackOptions::default();
     options.strip_components = 1;
-    let summary = tool.unpack_in_with(temp.path(), &mut options).unwrap();
+    let mut unpacker = EntryUnpacker::new(temp.path(), &mut options).unwrap();
+    let summary = unpacker.unpack(&mut tool).unwrap();
+    unpacker.finish().unwrap();
     assert_eq!(summary.files, 1);
     assert_eq!(std::fs::read(temp.path().join("tool")).unwrap(), b"hello");
     assert!(!temp.path().join("whiteout").exists());
@@ -141,7 +143,10 @@ fn entry_unpack_handles_sparse_data_and_rejects_traversal() {
     let temp = tempfile::tempdir().unwrap();
     let mut archive = Archive::new(Cursor::new(sparse));
     let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
-    let summary = entry.unpack_in(temp.path()).unwrap();
+    let mut options = UnpackOptions::default();
+    let mut unpacker = EntryUnpacker::new(temp.path(), &mut options).unwrap();
+    let summary = unpacker.unpack(&mut entry).unwrap();
+    unpacker.finish().unwrap();
     assert_eq!(summary.files, 1);
     assert_eq!(summary.sparse_files, 1);
     assert_eq!(
@@ -154,7 +159,9 @@ fn entry_unpack_handles_sparse_data_and_rejects_traversal() {
     terminate(&mut traversal);
     let mut archive = Archive::new(Cursor::new(traversal));
     let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
-    assert!(entry.unpack_in(temp.path()).is_err());
+    let mut options = UnpackOptions::default();
+    let mut unpacker = EntryUnpacker::new(temp.path(), &mut options).unwrap();
+    assert!(unpacker.unpack(&mut entry).is_err());
 }
 
 #[cfg(unix)]
@@ -169,8 +176,40 @@ fn entry_unpack_rejects_symlinked_parent() {
     terminate(&mut tar);
     let mut archive = Archive::new(Cursor::new(tar));
     let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
-    assert!(entry.unpack_in(temp.path()).is_err());
+    let mut options = UnpackOptions::default();
+    let mut unpacker = EntryUnpacker::new(temp.path(), &mut options).unwrap();
+    assert!(unpacker.unpack(&mut entry).is_err());
     assert!(!outside.path().join("escape").exists());
+}
+
+#[test]
+fn entry_unpacker_defers_directory_metadata_until_finish() {
+    let mut tar = Vec::new();
+    append_entry(&mut tar, header("dir/", 0, b'5'), b"");
+    append_entry(&mut tar, header("dir/file", 1, b'0'), b"x");
+    terminate(&mut tar);
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut archive = Archive::new(Cursor::new(tar));
+    let mut entries = archive.entries().unwrap();
+    let mut options = UnpackOptions::default();
+    let mut unpacker = EntryUnpacker::new(temp.path(), &mut options).unwrap();
+    unpacker
+        .unpack(&mut entries.next().unwrap().unwrap())
+        .unwrap();
+    unpacker
+        .unpack(&mut entries.next().unwrap().unwrap())
+        .unwrap();
+    unpacker.finish().unwrap();
+
+    let modified = std::fs::metadata(temp.path().join("dir"))
+        .unwrap()
+        .modified()
+        .unwrap()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert_eq!(modified, 1_700_000_000);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a stateful EntryUnpacker for secure selective extraction
- allow callers to inspect or skip entries before unpacking, including OCI whiteouts
- defer directory permissions and mtimes until EntryUnpacker::finish so child writes cannot clobber metadata
- return an UnpackSummary for every selected entry
- retain traversal, reserved-name, symlink-parent, sparse-file, metadata, and overwrite protections

## Why
Callers such as mise OCI layer processing need to inspect and selectively skip whiteout entries before extracting the remaining entries. Whole-archive extraction cannot express that workflow, while manually copying entries would duplicate security and sparse-file handling.

## Validation
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo doc --no-deps --all-features
- cargo check --target x86_64-pc-windows-msvc --all-targets --all-features
- targeted coverage for selective extraction, deferred directory metadata, sparse entries, traversal, and symlink-parent escape