### PR TITLE
feat: add streaming tar writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,7 @@ version = "1.0.0"
 dependencies = [
  "filetime",
  "flate2",
+ "tar",
  "tempfile",
 ]
 
@@ -139,6 +140,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,4 +176,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "jdx-tar"
 version = "1.0.0"
 edition = "2024"
 rust-version = "1.85"
-description = "Secure streaming tar extraction with complete GNU sparse support"
+description = "Secure streaming tar reading, writing, and GNU sparse extraction"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jdx/jdx-tar"
 homepage = "https://github.com/jdx/jdx-tar"
@@ -18,6 +18,7 @@ filetime = "0.2.25"
 
 [dev-dependencies]
 flate2 = "1"
+tar = "0.4"
 tempfile = "3.15"
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Documentation](https://docs.rs/jdx-tar/badge.svg)](https://docs.rs/jdx-tar)
 [![CI](https://github.com/jdx/jdx-tar/actions/workflows/ci.yml/badge.svg)](https://github.com/jdx/jdx-tar/actions/workflows/ci.yml)
 
-Synchronous, streaming tar extraction with support for all GNU sparse
-formats, including the PAX sparse formats that other pure-Rust tar crates
-cannot extract.
+Synchronous, streaming tar reading, writing, and extraction with support for
+all GNU sparse formats, including the PAX sparse formats that other pure-Rust
+tar crates cannot extract.
 
 ```rust
 use jdx_tar::{Archive, UnpackOptions};
@@ -20,6 +20,21 @@ println!("extracted {} files", summary.files);
 
 Input is anything that implements `Read`. Decompression is the caller's
 responsibility: wrap the file in a gzip/xz/zstd decoder first.
+
+Archives can also be written to any `Write` implementation:
+
+```rust
+use jdx_tar::{Builder, EntryType, Header};
+
+let mut output = Vec::new();
+let mut builder = Builder::new(&mut output);
+let mut header = Header::new_gnu(EntryType::File);
+header.set_mode(0o755);
+header.set_size(5);
+builder.append_data(&mut header, "bin/tool", &b"hello"[..])?;
+builder.finish()?;
+# Ok::<(), std::io::Error>(())
+```
 
 ## Why another tar crate?
 
@@ -46,13 +61,10 @@ contents are the raw sparse map and packed data.
 | Progress + per-entry callbacks             | ✅        | ❌                                             | ❌                                                                | ❌                  | ❌                      |
 | Secure extraction is the *only* mode       | ✅        | partial (unchecked `Entry::unpack` exists)     | ✅                                                                | ❌                  | ❌                      |
 | Pure Rust, no C, `unsafe_code = "forbid"`  | ✅        | ✅                                             | ✅                                                                | ❌ (links C)        | n/a                     |
-| Writes archives                            | ❌        | ✅                                             | ✅                                                                | ✅                  | ✅                      |
+| Writes archives                            | ✅        | ✅                                             | ✅                                                                | ✅                  | ✅                      |
 
 This crate's header parsing draws from the `tar` crate (see
-acknowledgements); use that or `astral-tokio-tar` if you need archive
-creation or an async API today. Archive writing is not implemented here yet,
-and a well-tested PR adding synchronous, streaming tar writing would be
-welcome.
+acknowledgements); use `astral-tokio-tar` if you need an async API.
 
 ## Features
 
@@ -70,6 +82,8 @@ welcome.
 - `EntryUnpacker` securely extracts selected entries, letting callers inspect
   or skip entries while retaining the same path, symlink, sparse-file, and
   deferred-directory-metadata handling as whole-archive extraction.
+- Deterministic, streaming GNU-format archive writing, including GNU long-name
+  and long-link records.
 - `strip_components` at any depth, applied after name resolution, plus
   `preserve_mtime`, `preserve_permissions`, and `overwrite`.
 - `on_progress` and `on_entry` callbacks. `unpack` returns an `UnpackSummary`

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -71,6 +71,10 @@ impl<W: Write> Builder<W> {
         ) {
             return Err(invalid("append_link requires a symlink or hardlink header"));
         }
+        let path = path_bytes(path.as_ref());
+        if path.is_empty() {
+            return Err(invalid("tar entry path is empty"));
+        }
         let target = path_bytes(target.as_ref());
         if target.is_empty() {
             return Err(invalid("tar link target is empty"));
@@ -78,9 +82,13 @@ impl<W: Write> Builder<W> {
         if target.len() > LINK_LEN {
             self.append_long_record(b'K', &target)?;
         }
+        if path.len() > NAME_LEN {
+            self.append_long_record(b'L', &path)?;
+        }
         header.link_name = Some(target);
         header.stored_size = 0;
-        self.append_data(header, path, io::empty())
+        header.path = path;
+        self.append_resolved(header, io::empty())
     }
 
     /// Writes the two zero blocks that terminate a tar archive.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,209 @@
+use super::{EntryType, Header, Result};
+use std::io::{self, ErrorKind, Read, Write};
+use std::path::Path;
+
+const BLOCK_LEN: usize = 512;
+const NAME_LEN: usize = 100;
+const LINK_LEN: usize = 100;
+
+/// A synchronous, streaming tar archive writer.
+///
+/// The writer emits deterministic GNU-format headers: unused fields are
+/// zeroed and checksums are always recalculated by the builder.
+pub struct Builder<W: Write> {
+    inner: W,
+    finished: bool,
+}
+
+impl<W: Write> Builder<W> {
+    /// Creates an archive writer around `inner`.
+    pub const fn new(inner: W) -> Self {
+        Self {
+            inner,
+            finished: false,
+        }
+    }
+
+    /// Appends an entry at `path`.
+    ///
+    /// Exactly `header.stored_size()` bytes are read from `data`. Paths longer
+    /// than the GNU header field are emitted using a GNU long-name record.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the path or header cannot be represented, the
+    /// input is shorter than its declared size, or writing fails.
+    pub fn append_data<P: AsRef<Path>, R: Read>(
+        &mut self,
+        header: &mut Header,
+        path: P,
+        data: R,
+    ) -> Result<()> {
+        let path = path_bytes(path.as_ref());
+        if path.is_empty() {
+            return Err(invalid("tar entry path is empty"));
+        }
+        if path.len() > NAME_LEN {
+            self.append_long_record(b'L', &path)?;
+        }
+        header.path = path;
+        self.append_resolved(header, data)
+    }
+
+    /// Appends a symbolic or hard link.
+    ///
+    /// Link targets longer than the GNU header field are emitted using a GNU
+    /// long-link record.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-link header, an empty target, an
+    /// unrepresentable header, or a write failure.
+    pub fn append_link<P: AsRef<Path>, T: AsRef<Path>>(
+        &mut self,
+        header: &mut Header,
+        path: P,
+        target: T,
+    ) -> Result<()> {
+        if !matches!(
+            EntryType::from_flag(header.type_flag),
+            EntryType::Symlink | EntryType::Hardlink
+        ) {
+            return Err(invalid("append_link requires a symlink or hardlink header"));
+        }
+        let target = path_bytes(target.as_ref());
+        if target.is_empty() {
+            return Err(invalid("tar link target is empty"));
+        }
+        if target.len() > LINK_LEN {
+            self.append_long_record(b'K', &target)?;
+        }
+        header.link_name = Some(target);
+        header.stored_size = 0;
+        self.append_data(header, path, io::empty())
+    }
+
+    /// Writes the two zero blocks that terminate a tar archive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing or flushing the wrapped writer fails.
+    pub fn finish(&mut self) -> Result<()> {
+        if !self.finished {
+            self.inner.write_all(&[0_u8; BLOCK_LEN * 2])?;
+            self.inner.flush()?;
+            self.finished = true;
+        }
+        Ok(())
+    }
+
+    /// Finishes the archive and returns the wrapped writer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when finishing the archive fails.
+    pub fn into_inner(mut self) -> Result<W> {
+        self.finish()?;
+        Ok(self.inner)
+    }
+
+    fn append_long_record(&mut self, flag: u8, value: &[u8]) -> Result<()> {
+        let size = value
+            .len()
+            .checked_add(1)
+            .and_then(|size| u64::try_from(size).ok())
+            .ok_or_else(|| invalid("GNU long-name record is too large"))?;
+        let mut header = Header::new_gnu(EntryType::Other(flag));
+        header.path = b"././@LongLink".to_vec();
+        header.mode = 0o644;
+        header.stored_size = size;
+        let mut data = value.to_vec();
+        data.push(0);
+        self.append_resolved(&header, data.as_slice())
+    }
+
+    fn append_resolved<R: Read>(&mut self, header: &Header, mut data: R) -> Result<()> {
+        if self.finished {
+            return Err(invalid("cannot append to a finished tar archive"));
+        }
+        let block = encode_header(header)?;
+        self.inner.write_all(&block)?;
+        let copied = io::copy(&mut data.by_ref().take(header.stored_size), &mut self.inner)?;
+        if copied != header.stored_size {
+            return Err(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "tar entry data is shorter than its header size",
+            ));
+        }
+        let padding = (512 - header.stored_size % 512) % 512;
+        if padding != 0 {
+            self.inner
+                .write_all(&[0_u8; BLOCK_LEN][..padding as usize])?;
+        }
+        Ok(())
+    }
+}
+
+fn encode_header(header: &Header) -> Result<[u8; BLOCK_LEN]> {
+    let mut block = [0_u8; BLOCK_LEN];
+    write_bytes(&mut block[..NAME_LEN], &header.path);
+    write_octal(&mut block[100..108], u64::from(header.mode), "mode")?;
+    write_octal(&mut block[108..116], header.uid, "uid")?;
+    write_octal(&mut block[116..124], header.gid, "gid")?;
+    write_octal(&mut block[124..136], header.stored_size, "size")?;
+    let mtime =
+        u64::try_from(header.mtime).map_err(|_| invalid("negative mtimes require a PAX header"))?;
+    write_octal(&mut block[136..148], mtime, "mtime")?;
+    block[148..156].fill(b' ');
+    block[156] = header.type_flag;
+    if let Some(target) = &header.link_name {
+        write_bytes(&mut block[157..257], target);
+    }
+    block[257..265].copy_from_slice(b"ustar  \0");
+    let checksum: u64 = block.iter().map(|byte| u64::from(*byte)).sum();
+    write_checksum(&mut block[148..156], checksum)?;
+    Ok(block)
+}
+
+fn write_bytes(field: &mut [u8], value: &[u8]) {
+    let len = value.len().min(field.len());
+    field[..len].copy_from_slice(&value[..len]);
+}
+
+fn write_octal(field: &mut [u8], value: u64, name: &'static str) -> Result<()> {
+    let digits = field.len() - 1;
+    let value = format!("{value:0digits$o}");
+    if value.len() > digits {
+        return Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("tar {name} does not fit in its header field"),
+        ));
+    }
+    field[..digits].copy_from_slice(value.as_bytes());
+    field[digits] = 0;
+    Ok(())
+}
+
+fn write_checksum(field: &mut [u8], checksum: u64) -> Result<()> {
+    let value = format!("{checksum:06o}\0 ");
+    if value.len() != field.len() {
+        return Err(invalid("tar checksum does not fit in its header field"));
+    }
+    field.copy_from_slice(value.as_bytes());
+    Ok(())
+}
+
+#[cfg(unix)]
+fn path_bytes(path: &Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(not(unix))]
+fn path_bytes(path: &Path) -> Vec<u8> {
+    path.to_string_lossy().replace('\\', "/").into_bytes()
+}
+
+fn invalid(message: &'static str) -> io::Error {
+    io::Error::new(ErrorKind::InvalidInput, message)
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -13,6 +13,7 @@ const LINK_LEN: usize = 100;
 pub struct Builder<W: Write> {
     inner: W,
     finished: bool,
+    poisoned: bool,
 }
 
 impl<W: Write> Builder<W> {
@@ -21,6 +22,7 @@ impl<W: Write> Builder<W> {
         Self {
             inner,
             finished: false,
+            poisoned: false,
         }
     }
 
@@ -43,10 +45,11 @@ impl<W: Write> Builder<W> {
         if path.is_empty() {
             return Err(invalid("tar entry path is empty"));
         }
+        header.path.clone_from(&path);
+        encode_header(header)?;
         if path.len() > NAME_LEN {
             self.append_long_record(b'L', &path)?;
         }
-        header.path = path;
         self.append_resolved(header, data)
     }
 
@@ -79,15 +82,20 @@ impl<W: Write> Builder<W> {
         if target.is_empty() {
             return Err(invalid("tar link target is empty"));
         }
-        if target.len() > LINK_LEN {
-            self.append_long_record(b'K', &target)?;
+        header.link_name = Some(target);
+        header.stored_size = 0;
+        header.path.clone_from(&path);
+        encode_header(header)?;
+        if let Some(target) = header
+            .link_name
+            .as_deref()
+            .filter(|target| target.len() > LINK_LEN)
+        {
+            self.append_long_record(b'K', target)?;
         }
         if path.len() > NAME_LEN {
             self.append_long_record(b'L', &path)?;
         }
-        header.link_name = Some(target);
-        header.stored_size = 0;
-        header.path = path;
         self.append_resolved(header, io::empty())
     }
 
@@ -97,9 +105,18 @@ impl<W: Write> Builder<W> {
     ///
     /// Returns an error when writing or flushing the wrapped writer fails.
     pub fn finish(&mut self) -> Result<()> {
+        if self.poisoned {
+            return Err(invalid("cannot finish a poisoned tar archive"));
+        }
         if !self.finished {
-            self.inner.write_all(&[0_u8; BLOCK_LEN * 2])?;
-            self.inner.flush()?;
+            if let Err(error) = self
+                .inner
+                .write_all(&[0_u8; BLOCK_LEN * 2])
+                .and_then(|()| self.inner.flush())
+            {
+                self.poisoned = true;
+                return Err(error);
+            }
             self.finished = true;
         }
         Ok(())
@@ -131,24 +148,33 @@ impl<W: Write> Builder<W> {
     }
 
     fn append_resolved<R: Read>(&mut self, header: &Header, mut data: R) -> Result<()> {
+        if self.poisoned {
+            return Err(invalid("cannot append to a poisoned tar archive"));
+        }
         if self.finished {
             return Err(invalid("cannot append to a finished tar archive"));
         }
         let block = encode_header(header)?;
-        self.inner.write_all(&block)?;
-        let copied = io::copy(&mut data.by_ref().take(header.stored_size), &mut self.inner)?;
-        if copied != header.stored_size {
-            return Err(io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "tar entry data is shorter than its header size",
-            ));
+        let result = (|| {
+            self.inner.write_all(&block)?;
+            let copied = io::copy(&mut data.by_ref().take(header.stored_size), &mut self.inner)?;
+            if copied != header.stored_size {
+                return Err(io::Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "tar entry data is shorter than its header size",
+                ));
+            }
+            let padding = (512 - header.stored_size % 512) % 512;
+            if padding != 0 {
+                self.inner
+                    .write_all(&[0_u8; BLOCK_LEN][..padding as usize])?;
+            }
+            Ok(())
+        })();
+        if result.is_err() {
+            self.poisoned = true;
         }
-        let padding = (512 - header.stored_size % 512) % 512;
-        if padding != 0 {
-            self.inner
-                .write_all(&[0_u8; BLOCK_LEN][..padding as usize])?;
-        }
-        Ok(())
+        result
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use super::{EntryType, Header, Result};
+use super::{EntryType, Header, MAX_METADATA_SIZE, Result};
 use std::io::{self, ErrorKind, Read, Write};
 use std::path::Path;
 
@@ -46,6 +46,9 @@ impl<W: Write> Builder<W> {
             return Err(invalid("tar entry path is empty"));
         }
         header.path.clone_from(&path);
+        if path.len() > NAME_LEN {
+            long_record_size(&path)?;
+        }
         encode_header(header)?;
         if path.len() > NAME_LEN {
             self.append_long_record(b'L', &path)?;
@@ -85,6 +88,16 @@ impl<W: Write> Builder<W> {
         header.link_name = Some(target);
         header.stored_size = 0;
         header.path.clone_from(&path);
+        if let Some(target) = header
+            .link_name
+            .as_deref()
+            .filter(|target| target.len() > LINK_LEN)
+        {
+            long_record_size(target)?;
+        }
+        if path.len() > NAME_LEN {
+            long_record_size(&path)?;
+        }
         encode_header(header)?;
         if let Some(target) = header
             .link_name
@@ -133,11 +146,7 @@ impl<W: Write> Builder<W> {
     }
 
     fn append_long_record(&mut self, flag: u8, value: &[u8]) -> Result<()> {
-        let size = value
-            .len()
-            .checked_add(1)
-            .and_then(|size| u64::try_from(size).ok())
-            .ok_or_else(|| invalid("GNU long-name record is too large"))?;
+        let size = long_record_size(value)?;
         let mut header = Header::new_gnu(EntryType::Other(flag));
         header.path = b"././@LongLink".to_vec();
         header.mode = 0o644;
@@ -176,6 +185,18 @@ impl<W: Write> Builder<W> {
         }
         result
     }
+}
+
+fn long_record_size(value: &[u8]) -> Result<u64> {
+    let size = value
+        .len()
+        .checked_add(1)
+        .and_then(|size| u64::try_from(size).ok())
+        .ok_or_else(|| invalid("GNU long-name record is too large"))?;
+    if size > MAX_METADATA_SIZE {
+        return Err(invalid("GNU long-name record exceeds 1 MiB limit"));
+    }
+    Ok(size)
 }
 
 fn encode_header(header: &Header) -> Result<[u8; BLOCK_LEN]> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
-//! A secure, synchronous, streaming tar reader and extractor.
+//! A secure, synchronous, streaming tar reader, writer, and extractor.
 //!
 //! This crate reads already-decompressed tar streams and supports all GNU
 //! sparse formats commonly found in release archives.
 
+mod builder;
 mod format;
 mod unpack;
 
@@ -15,6 +16,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::rc::Rc;
 
+pub use builder::Builder;
 use format::{
     apply_pax_header, bytes_to_path, parse_decimal, parse_header, parse_number, parse_pax,
     parse_sparse_csv, parse_sparse_pairs, pax_text_checked, pax_u64_checked, pax_value,
@@ -77,6 +79,19 @@ impl EntryType {
             other => Self::Other(other),
         }
     }
+
+    const fn type_flag(self) -> u8 {
+        match self {
+            Self::File => b'0',
+            Self::Directory => b'5',
+            Self::Symlink => b'2',
+            Self::Hardlink => b'1',
+            Self::CharDevice => b'3',
+            Self::BlockDevice => b'4',
+            Self::Fifo => b'6',
+            Self::Other(flag) => flag,
+        }
+    }
 }
 
 /// Parsed metadata for a tar header.
@@ -93,6 +108,25 @@ pub struct Header {
 }
 
 impl Header {
+    /// Creates a deterministic GNU-format header for `entry_type`.
+    ///
+    /// Numeric fields default to zero. Callers must set the entry size before
+    /// appending regular-file data. Paths and checksums are populated by
+    /// [`Builder`].
+    #[must_use]
+    pub fn new_gnu(entry_type: EntryType) -> Self {
+        Self {
+            path: Vec::new(),
+            link_name: None,
+            mode: 0,
+            uid: 0,
+            gid: 0,
+            stored_size: 0,
+            mtime: 0,
+            type_flag: entry_type.type_flag(),
+        }
+    }
+
     /// File mode from the header.
     #[must_use]
     pub const fn mode(&self) -> u32 {
@@ -122,6 +156,31 @@ impl Header {
     #[must_use]
     pub const fn type_flag(&self) -> u8 {
         self.type_flag
+    }
+
+    /// Sets the file mode stored in the header.
+    pub const fn set_mode(&mut self, mode: u32) {
+        self.mode = mode;
+    }
+
+    /// Sets the numeric user id stored in the header.
+    pub const fn set_uid(&mut self, uid: u64) {
+        self.uid = uid;
+    }
+
+    /// Sets the numeric group id stored in the header.
+    pub const fn set_gid(&mut self, gid: u64) {
+        self.gid = gid;
+    }
+
+    /// Sets the number of data bytes that follow the header.
+    pub const fn set_size(&mut self, size: u64) {
+        self.stored_size = size;
+    }
+
+    /// Sets the modification time as seconds since the Unix epoch.
+    pub const fn set_mtime(&mut self, mtime: i64) {
+        self.mtime = mtime;
     }
     /// Link target, when present.
     pub fn link_name(&self) -> Option<Cow<'_, Path>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use unpack::{
 use unpack::{ProgressReporter, unpack_archive};
 
 const BLOCK: u64 = 512;
-const MAX_PAX_SIZE: u64 = 1024 * 1024;
+const MAX_METADATA_SIZE: u64 = 1024 * 1024;
 const MAX_SPARSE_SEGMENTS: usize = 1_000_000;
 
 /// The crate's result type.
@@ -369,7 +369,7 @@ impl<R: Read> Entries<'_, R> {
             let size = header.stored_size;
 
             if matches!(flag, b'x' | b'g' | b'L' | b'K') {
-                if size > MAX_PAX_SIZE {
+                if size > MAX_METADATA_SIZE {
                     return Err(error(
                         ErrorKind::InvalidData,
                         "tar metadata exceeds 1 MiB limit",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ impl Header {
     pub const fn set_mtime(&mut self, mtime: i64) {
         self.mtime = mtime;
     }
+
     /// Link target, when present.
     pub fn link_name(&self) -> Option<Cow<'_, Path>> {
         self.link_name.as_deref().map(bytes_to_path)

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -110,3 +110,24 @@ fn output_is_compatible_with_tar_rs() {
     entry.read_to_string(&mut contents).unwrap();
     assert_eq!(contents, "backend");
 }
+
+#[test]
+fn invalid_link_does_not_write_partial_metadata() {
+    let mut builder = Builder::new(Vec::new());
+    let mut link = Header::new_gnu(EntryType::Symlink);
+    let long_target = "target/".repeat(20);
+    assert!(builder.append_link(&mut link, "", long_target).is_err());
+
+    let mut file = Header::new_gnu(EntryType::File);
+    file.set_size(2);
+    builder.append_data(&mut file, "ok", &b"ok"[..]).unwrap();
+    let bytes = builder.into_inner().unwrap();
+
+    let mut archive = Archive::new(Cursor::new(bytes));
+    let mut entries = archive.entries().unwrap();
+    assert_eq!(
+        entries.next().unwrap().unwrap().path().unwrap().as_ref(),
+        std::path::Path::new("ok")
+    );
+    assert!(entries.next().is_none());
+}

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,0 +1,112 @@
+use jdx_tar::{Archive, Builder, EntryType, Header};
+use std::io::{Cursor, Read};
+
+#[test]
+fn writes_streaming_archive_with_metadata_and_links() {
+    let mut bytes = Vec::new();
+    let target = format!("../{}", "deep/".repeat(30));
+    {
+        let mut builder = Builder::new(&mut bytes);
+
+        let mut dir = Header::new_gnu(EntryType::Directory);
+        dir.set_mode(0o755);
+        builder
+            .append_data(&mut dir, "pkg/", std::io::empty())
+            .unwrap();
+
+        let mut file = Header::new_gnu(EntryType::File);
+        file.set_mode(0o755);
+        file.set_uid(1000);
+        file.set_gid(1001);
+        file.set_mtime(42);
+        file.set_size(5);
+        builder
+            .append_data(&mut file, "pkg/tool", &b"hello"[..])
+            .unwrap();
+
+        let mut link = Header::new_gnu(EntryType::Symlink);
+        link.set_mode(0o777);
+        builder.append_link(&mut link, "pkg/link", &target).unwrap();
+        builder.finish().unwrap();
+    }
+
+    assert_eq!(bytes.len() % 512, 0);
+    let mut archive = Archive::new(Cursor::new(bytes));
+    let mut entries = archive.entries().unwrap();
+
+    let dir = entries.next().unwrap().unwrap();
+    assert_eq!(dir.path().unwrap().as_ref(), std::path::Path::new("pkg/"));
+    assert_eq!(dir.entry_type(), EntryType::Directory);
+
+    let mut file = entries.next().unwrap().unwrap();
+    assert_eq!(
+        file.path().unwrap().as_ref(),
+        std::path::Path::new("pkg/tool")
+    );
+    assert_eq!(file.header().mode(), 0o755);
+    assert_eq!(file.header().uid(), 1000);
+    assert_eq!(file.header().gid(), 1001);
+    assert_eq!(file.header().mtime(), 42);
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    assert_eq!(contents, "hello");
+
+    let link = entries.next().unwrap().unwrap();
+    assert_eq!(link.entry_type(), EntryType::Symlink);
+    assert_eq!(
+        link.header().link_name().unwrap().as_ref(),
+        std::path::Path::new(&target)
+    );
+    assert!(entries.next().is_none());
+}
+
+#[test]
+fn writes_long_paths_and_rejects_short_data() {
+    let long_path = format!("root/{}/tool", "nested/".repeat(20));
+    let mut bytes = Vec::new();
+    {
+        let mut builder = Builder::new(&mut bytes);
+        let mut header = Header::new_gnu(EntryType::File);
+        header.set_size(1);
+        builder
+            .append_data(&mut header, &long_path, &b"x"[..])
+            .unwrap();
+        builder.finish().unwrap();
+    }
+
+    let mut archive = Archive::new(Cursor::new(bytes));
+    let entry = archive.entries().unwrap().next().unwrap().unwrap();
+    assert_eq!(
+        entry.path().unwrap().as_ref(),
+        std::path::Path::new(&long_path)
+    );
+
+    let mut builder = Builder::new(Vec::new());
+    let mut header = Header::new_gnu(EntryType::File);
+    header.set_size(2);
+    let error = builder
+        .append_data(&mut header, "short", &b"x"[..])
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+}
+
+#[test]
+fn output_is_compatible_with_tar_rs() {
+    let mut builder = Builder::new(Vec::new());
+    let mut header = Header::new_gnu(EntryType::File);
+    header.set_size(7);
+    builder
+        .append_data(&mut header, "registry/tool.toml", &b"backend"[..])
+        .unwrap();
+    let bytes = builder.into_inner().unwrap();
+
+    let mut archive = tar::Archive::new(Cursor::new(bytes));
+    let mut entry = archive.entries().unwrap().next().unwrap().unwrap();
+    assert_eq!(
+        entry.path().unwrap().as_ref(),
+        std::path::Path::new("registry/tool.toml")
+    );
+    let mut contents = String::new();
+    entry.read_to_string(&mut contents).unwrap();
+    assert_eq!(contents, "backend");
+}

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -138,3 +138,41 @@ fn invalid_link_does_not_write_partial_metadata() {
     );
     assert!(entries.next().is_none());
 }
+
+#[test]
+fn oversized_long_records_do_not_write_partial_metadata() {
+    let oversized = "x".repeat(1024 * 1024);
+    let mut builder = Builder::new(Vec::new());
+
+    let mut file = Header::new_gnu(EntryType::File);
+    let error = builder
+        .append_data(&mut file, &oversized, std::io::empty())
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+
+    let mut link = Header::new_gnu(EntryType::Symlink);
+    let long_target = "t".repeat(101);
+    let error = builder
+        .append_link(&mut link, &oversized, &long_target)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+
+    let mut link = Header::new_gnu(EntryType::Symlink);
+    let error = builder
+        .append_link(&mut link, "oversized-target", &oversized)
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+
+    let mut valid = Header::new_gnu(EntryType::File);
+    valid.set_size(2);
+    builder.append_data(&mut valid, "ok", &b"ok"[..]).unwrap();
+    let bytes = builder.into_inner().unwrap();
+
+    let mut archive = Archive::new(Cursor::new(bytes));
+    let mut entries = archive.entries().unwrap();
+    assert_eq!(
+        entries.next().unwrap().unwrap().path().unwrap().as_ref(),
+        std::path::Path::new("ok")
+    );
+    assert!(entries.next().is_none());
+}

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -88,6 +88,13 @@ fn writes_long_paths_and_rejects_short_data() {
         .append_data(&mut header, "short", &b"x"[..])
         .unwrap_err();
     assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+    let mut next = Header::new_gnu(EntryType::File);
+    assert!(
+        builder
+            .append_data(&mut next, "next", std::io::empty())
+            .is_err()
+    );
+    assert!(builder.finish().is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a synchronous streaming Builder for deterministic GNU-format archives
- add writable Header metadata for mode, owner, size, and mtime
- support regular files, directories, symlinks, hardlinks, GNU long names, and GNU long links
- document archive creation and update the capability matrix

## Why
mise still needs tar-rs to construct reproducible OCI image layers. This writer covers that call site while preserving jdx-tar properties: synchronous streaming I/O, no unsafe code, and no new runtime dependencies.

## Validation
- cargo test --all-features
- cargo clippy --all-targets --all-features -- -D warnings
- cargo doc --no-deps --all-features
- cargo check --target x86_64-pc-windows-msvc --all-targets --all-features
- writer output parsed by both jdx-tar and tar-rs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public write path and tar on-wire encoding, but behavior is covered by round-trip and tar-rs compatibility tests and does not change secure extraction semantics beyond sharing the metadata size limit.
> 
> **Overview**
> Adds synchronous **archive writing** via a public `Builder<W: Write>` so callers can stream GNU-format tar to any writer without pulling in `tar-rs` for creation (e.g. reproducible OCI layers).
> 
> The builder supports `append_data` (files/directories with declared size), `append_link` (symlinks/hardlinks), automatic **GNU long-name (`L`) and long-link (`K`)** records, 512-byte padding, and terminating zero blocks. Headers are built with `Header::new_gnu` plus new setters for mode, uid, gid, size, and mtime; checksums and ustar fields are filled deterministically. Failed writes **poison** the builder so later appends/finish fail cleanly; validation rejects empty paths, short payload vs header size, and long records over the existing **1 MiB metadata cap** (reader limit renamed from `MAX_PAX_SIZE` to `MAX_METADATA_SIZE`).
> 
> Docs and the feature matrix now claim write support; integration tests round-trip through `jdx-tar` and `tar-rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2084b21e7bc60a9850c405cb627e245789a5dd5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->