### PR TITLE
fix: harden tar parsing and extraction invariants

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -224,13 +224,11 @@ fn long_record_size(value: &[u8]) -> Result<u64> {
 fn encode_header(header: &Header) -> Result<[u8; BLOCK_LEN]> {
     let mut block = [0_u8; BLOCK_LEN];
     write_bytes(&mut block[..NAME_LEN], &header.path);
-    write_octal(&mut block[100..108], u64::from(header.mode), "mode")?;
-    write_octal(&mut block[108..116], header.uid, "uid")?;
-    write_octal(&mut block[116..124], header.gid, "gid")?;
-    write_octal(&mut block[124..136], header.stored_size, "size")?;
-    let mtime =
-        u64::try_from(header.mtime).map_err(|_| invalid("negative mtimes require a PAX header"))?;
-    write_octal(&mut block[136..148], mtime, "mtime")?;
+    write_numeric(&mut block[100..108], u64::from(header.mode), "mode")?;
+    write_numeric(&mut block[108..116], header.uid, "uid")?;
+    write_numeric(&mut block[116..124], header.gid, "gid")?;
+    write_numeric(&mut block[124..136], header.stored_size, "size")?;
+    write_signed_numeric(&mut block[136..148], header.mtime, "mtime")?;
     block[148..156].fill(b' ');
     block[156] = header.type_flag;
     if let Some(target) = &header.link_name {
@@ -247,17 +245,40 @@ fn write_bytes(field: &mut [u8], value: &[u8]) {
     field[..len].copy_from_slice(&value[..len]);
 }
 
-fn write_octal(field: &mut [u8], value: u64, name: &'static str) -> Result<()> {
+fn write_numeric(field: &mut [u8], value: u64, name: &'static str) -> Result<()> {
     let digits = field.len() - 1;
-    let value = format!("{value:0digits$o}");
-    if value.len() > digits {
+    let octal = format!("{value:0digits$o}");
+    if octal.len() <= digits {
+        field[..digits].copy_from_slice(octal.as_bytes());
+        field[digits] = 0;
+        return Ok(());
+    }
+
+    if field.len() < 9 && value >= (1_u64 << ((field.len() - 1) * 8)) {
         return Err(io::Error::new(
             ErrorKind::InvalidInput,
             format!("tar {name} does not fit in its header field"),
         ));
     }
-    field[..digits].copy_from_slice(value.as_bytes());
-    field[digits] = 0;
+    field.fill(0);
+    let encoded = value.to_be_bytes();
+    let start = field.len().saturating_sub(encoded.len());
+    let source = encoded.len().saturating_sub(field.len());
+    field[start..].copy_from_slice(&encoded[source..]);
+    field[0] |= 0x80;
+    Ok(())
+}
+
+fn write_signed_numeric(field: &mut [u8], value: i64, name: &'static str) -> Result<()> {
+    if value >= 0 {
+        return write_numeric(field, value.unsigned_abs(), name);
+    }
+    field.fill(0xff);
+    let encoded = value.to_be_bytes();
+    let start = field.len().saturating_sub(encoded.len());
+    let source = encoded.len().saturating_sub(field.len());
+    field[start..].copy_from_slice(&encoded[source..]);
+    field[0] |= 0x80;
     Ok(())
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,4 @@
+use super::format::path_requires_directory;
 use super::{EntryType, Header, MAX_METADATA_SIZE, Result};
 use std::io::{self, ErrorKind, Read, Write};
 use std::path::Path;
@@ -45,6 +46,14 @@ impl<W: Write> Builder<W> {
         if path.is_empty() {
             return Err(invalid("tar entry path is empty"));
         }
+        validate_directory_suffix(&path, header.type_flag == b'5')?;
+        if let Some(target) = header
+            .link_name
+            .as_deref()
+            .filter(|_| header.type_flag == b'1')
+        {
+            validate_directory_suffix(target, false)?;
+        }
         header.path.clone_from(&path);
         if path.len() > NAME_LEN {
             long_record_size(&path)?;
@@ -81,9 +90,13 @@ impl<W: Write> Builder<W> {
         if path.is_empty() {
             return Err(invalid("tar entry path is empty"));
         }
+        validate_directory_suffix(&path, false)?;
         let target = path_bytes(target.as_ref());
         if target.is_empty() {
             return Err(invalid("tar link target is empty"));
+        }
+        if header.type_flag == b'1' {
+            validate_directory_suffix(&target, false)?;
         }
         header.link_name = Some(target);
         header.stored_size = 0;
@@ -185,6 +198,15 @@ impl<W: Write> Builder<W> {
         }
         result
     }
+}
+
+fn validate_directory_suffix(path: &[u8], is_directory: bool) -> Result<()> {
+    if !is_directory && path_requires_directory(path) {
+        return Err(invalid(
+            "only directory entries may have a directory-required path suffix",
+        ));
+    }
+    Ok(())
 }
 
 fn long_record_size(value: &[u8]) -> Result<u64> {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -27,42 +27,66 @@ impl<W: Write> Builder<W> {
         }
     }
 
-    /// Appends an entry at `path`.
+    /// Appends a logical entry at `path`.
     ///
     /// Exactly `header.stored_size()` bytes are read from `data`. Paths longer
-    /// than the GNU header field are emitted using a GNU long-name record.
+    /// than the GNU header field are emitted using a GNU long-name record. Raw
+    /// extension and sparse headers are not accepted through this entry API.
     ///
     /// # Errors
     ///
     /// Returns an error when the path or header cannot be represented, the
-    /// input is shorter than its declared size, or writing fails.
+    /// entry type or payload shape is unsupported, the input is shorter than its
+    /// declared size, or writing fails. The caller header changes only on success.
     pub fn append_data<P: AsRef<Path>, R: Read>(
         &mut self,
         header: &mut Header,
         path: P,
         data: R,
     ) -> Result<()> {
+        self.ensure_writable()?;
+        if matches!(header.type_flag, b'x' | b'g' | b'L' | b'K' | b'S') {
+            return Err(invalid(
+                "raw extension and sparse headers are not logical writer entries",
+            ));
+        }
+        if matches!(header.type_flag, b'1'..=b'6') && header.stored_size != 0 {
+            return Err(invalid("nonregular entries cannot carry payload"));
+        }
+        let link_target = if matches!(header.type_flag, b'1' | b'2') {
+            let target = header
+                .link_name
+                .as_deref()
+                .ok_or_else(|| invalid("tar link target is missing"))?;
+            validate_name(target, "tar link target is empty or contains NUL")?;
+            if target.len() > LINK_LEN {
+                long_record_size(target)?;
+            }
+            if header.type_flag == b'1' {
+                validate_directory_suffix(target, false)?;
+            }
+            Some(target)
+        } else {
+            None
+        };
         let path = path_bytes(path.as_ref());
-        if path.is_empty() {
-            return Err(invalid("tar entry path is empty"));
-        }
+        validate_name(&path, "tar entry path is empty or contains NUL")?;
         validate_directory_suffix(&path, header.type_flag == b'5')?;
-        if let Some(target) = header
-            .link_name
-            .as_deref()
-            .filter(|_| header.type_flag == b'1')
-        {
-            validate_directory_suffix(target, false)?;
-        }
-        header.path.clone_from(&path);
         if path.len() > NAME_LEN {
             long_record_size(&path)?;
         }
-        encode_header(header)?;
+        let mut resolved = header.clone();
+        resolved.path.clone_from(&path);
+        encode_header(&resolved)?;
+        if let Some(target) = link_target.filter(|target| target.len() > LINK_LEN) {
+            self.append_long_record(b'K', target)?;
+        }
         if path.len() > NAME_LEN {
             self.append_long_record(b'L', &path)?;
         }
-        self.append_resolved(header, data)
+        self.append_resolved(&resolved, data)?;
+        *header = resolved;
+        Ok(())
     }
 
     /// Appends a symbolic or hard link.
@@ -80,6 +104,7 @@ impl<W: Write> Builder<W> {
         path: P,
         target: T,
     ) -> Result<()> {
+        self.ensure_writable()?;
         if !matches!(
             EntryType::from_flag(header.type_flag),
             EntryType::Symlink | EntryType::Hardlink
@@ -87,21 +112,18 @@ impl<W: Write> Builder<W> {
             return Err(invalid("append_link requires a symlink or hardlink header"));
         }
         let path = path_bytes(path.as_ref());
-        if path.is_empty() {
-            return Err(invalid("tar entry path is empty"));
-        }
+        validate_name(&path, "tar entry path is empty or contains NUL")?;
         validate_directory_suffix(&path, false)?;
         let target = path_bytes(target.as_ref());
-        if target.is_empty() {
-            return Err(invalid("tar link target is empty"));
-        }
+        validate_name(&target, "tar link target is empty or contains NUL")?;
         if header.type_flag == b'1' {
             validate_directory_suffix(&target, false)?;
         }
-        header.link_name = Some(target);
-        header.stored_size = 0;
-        header.path.clone_from(&path);
-        if let Some(target) = header
+        let mut resolved = header.clone();
+        resolved.link_name = Some(target);
+        resolved.stored_size = 0;
+        resolved.path.clone_from(&path);
+        if let Some(target) = resolved
             .link_name
             .as_deref()
             .filter(|target| target.len() > LINK_LEN)
@@ -111,8 +133,8 @@ impl<W: Write> Builder<W> {
         if path.len() > NAME_LEN {
             long_record_size(&path)?;
         }
-        encode_header(header)?;
-        if let Some(target) = header
+        encode_header(&resolved)?;
+        if let Some(target) = resolved
             .link_name
             .as_deref()
             .filter(|target| target.len() > LINK_LEN)
@@ -122,7 +144,9 @@ impl<W: Write> Builder<W> {
         if path.len() > NAME_LEN {
             self.append_long_record(b'L', &path)?;
         }
-        self.append_resolved(header, io::empty())
+        self.append_resolved(&resolved, io::empty())?;
+        *header = resolved;
+        Ok(())
     }
 
     /// Writes the two zero blocks that terminate a tar archive.
@@ -169,13 +193,18 @@ impl<W: Write> Builder<W> {
         self.append_resolved(&header, data.as_slice())
     }
 
-    fn append_resolved<R: Read>(&mut self, header: &Header, mut data: R) -> Result<()> {
+    fn ensure_writable(&self) -> Result<()> {
         if self.poisoned {
             return Err(invalid("cannot append to a poisoned tar archive"));
         }
         if self.finished {
             return Err(invalid("cannot append to a finished tar archive"));
         }
+        Ok(())
+    }
+
+    fn append_resolved<R: Read>(&mut self, header: &Header, mut data: R) -> Result<()> {
+        self.ensure_writable()?;
         let block = encode_header(header)?;
         let result = (|| {
             self.inner.write_all(&block)?;
@@ -205,6 +234,13 @@ fn validate_directory_suffix(path: &[u8], is_directory: bool) -> Result<()> {
         return Err(invalid(
             "only directory entries may have a directory-required path suffix",
         ));
+    }
+    Ok(())
+}
+
+fn validate_name(value: &[u8], message: &'static str) -> Result<()> {
+    if value.is_empty() || value.contains(&0) {
+        return Err(invalid(message));
     }
     Ok(())
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -245,7 +245,7 @@ pub(super) fn parse_sparse_pairs(
     let mut pairs = pax
         .iter()
         .filter(|(key, _)| matches!(key.as_str(), "GNU.sparse.offset" | "GNU.sparse.numbytes"));
-    let mut map = Vec::with_capacity(count);
+    let mut map = Vec::new();
     for _ in 0..count {
         let offset = pairs
             .next()

--- a/src/format.rs
+++ b/src/format.rs
@@ -306,7 +306,7 @@ pub(super) fn validate_sparse(
 }
 
 pub(super) fn trim_metadata(mut data: Vec<u8>) -> Vec<u8> {
-    while data.last().is_some_and(|byte| *byte == 0 || *byte == b'\n') {
+    while data.last() == Some(&0) {
         data.pop();
     }
     data

--- a/src/format.rs
+++ b/src/format.rs
@@ -171,9 +171,6 @@ pub(super) fn apply_pax_header(header: &mut Header, pax: &[(String, Vec<u8>)]) -
     if let Some(size) = pax_u64_checked(pax, "size")? {
         header.stored_size = size;
     }
-    if let Some(mode) = pax_u64_checked(pax, "mode")? {
-        header.mode = u32::try_from(mode).map_err(|_| invalid("PAX mode is too large"))?;
-    }
     if let Some(uid) = pax_u64_checked(pax, "uid")? {
         header.uid = uid;
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -9,6 +9,9 @@ pub(super) fn parse_header(block: &[u8; 512]) -> Result<Header> {
     let magic = &block[257..263];
     let prefix = nul_bytes(&block[345..500]);
     if !prefix.is_empty() && magic == b"ustar\0" {
+        if &block[263..265] != b"00" {
+            return Err(invalid("noncanonical USTAR header cannot carry a prefix"));
+        }
         let mut combined = prefix.to_vec();
         combined.push(b'/');
         combined.extend_from_slice(&path);

--- a/src/format.rs
+++ b/src/format.rs
@@ -133,7 +133,7 @@ pub(super) fn parse_pax(data: &[u8]) -> Result<Vec<(String, Vec<u8>)>> {
         if length == 0
             || cursor
                 .checked_add(length)
-                .is_none_or(|end| end > data.len())
+                .is_none_or(|end| end > data.len() || end < space + 1)
         {
             return Err(invalid("PAX record exceeds extension body"));
         }

--- a/src/format.rs
+++ b/src/format.rs
@@ -108,14 +108,15 @@ pub(super) fn parse_number(field: &[u8]) -> Result<u64> {
 
 pub(super) fn parse_signed_number(field: &[u8]) -> Result<i64> {
     if field.first().is_some_and(|byte| byte & 0x80 != 0) && field[0] & 0x40 != 0 {
+        let start = field.len().saturating_sub(8);
+        if field[..start].iter().any(|byte| *byte != 0xff)
+            || (start != 0 && field[start] & 0x80 == 0)
+        {
+            return Err(invalid("signed numeric field overflow"));
+        }
         let mut bytes = [0xff_u8; 8];
-        let source = if field.len() > 8 {
-            &field[field.len() - 8..]
-        } else {
-            field
-        };
+        let source = &field[start..];
         bytes[8 - source.len()..].copy_from_slice(source);
-        bytes[8 - source.len()] &= 0x7f;
         return Ok(i64::from_be_bytes(bytes));
     }
     i64::try_from(parse_number(field)?).map_err(|_| invalid("signed numeric field overflow"))
@@ -188,8 +189,7 @@ pub(super) fn apply_pax_header(header: &mut Header, pax: &[(String, Vec<u8>)]) -
         header.gid = gid;
     }
     if let Some(mtime) = pax_text_checked(pax, "mtime")? {
-        let integral = mtime.split('.').next().unwrap_or(mtime);
-        header.mtime = integral.parse().map_err(|_| invalid("invalid PAX mtime"))?;
+        header.mtime = parse_pax_mtime(mtime)?;
     }
     Ok(())
 }
@@ -336,6 +336,29 @@ pub(super) fn bytes_to_path(bytes: &[u8]) -> Cow<'_, Path> {
 #[cfg(not(unix))]
 pub(super) fn bytes_to_path(bytes: &[u8]) -> Cow<'_, Path> {
     Cow::Owned(PathBuf::from(String::from_utf8_lossy(bytes).into_owned()))
+}
+
+fn parse_pax_mtime(value: &str) -> Result<i64> {
+    let (integral, fraction) = match value.split_once('.') {
+        Some((integral, fraction))
+            if !fraction.is_empty() && fraction.bytes().all(|byte| byte.is_ascii_digit()) =>
+        {
+            (integral, Some(fraction))
+        }
+        Some(_) => return Err(invalid("invalid PAX mtime")),
+        None => (value, None),
+    };
+    let negative = integral.starts_with('-');
+    let seconds = integral
+        .parse::<i64>()
+        .map_err(|_| invalid("invalid PAX mtime"))?;
+    if negative && fraction.is_some_and(|fraction| fraction.bytes().any(|byte| byte != b'0')) {
+        seconds
+            .checked_sub(1)
+            .ok_or_else(|| invalid("PAX mtime is out of range"))
+    } else {
+        Ok(seconds)
+    }
 }
 
 #[cfg(test)]

--- a/src/format.rs
+++ b/src/format.rs
@@ -264,8 +264,13 @@ pub(super) fn push_sparse_pair(
     offset: &[u8],
     len: &[u8],
 ) -> Result<bool> {
-    if offset.first() == Some(&0) {
+    let offset_empty = offset.first() == Some(&0);
+    let len_empty = len.first() == Some(&0);
+    if offset_empty && len_empty {
         return Ok(false);
+    }
+    if offset_empty || len_empty {
+        return Err(invalid("partial old GNU sparse map entry"));
     }
     let offset = parse_number(offset)?;
     let len = parse_number(len)?;

--- a/src/format.rs
+++ b/src/format.rs
@@ -72,22 +72,26 @@ pub(super) fn parse_number(field: &[u8]) -> Result<u64> {
         }
         return Ok(value);
     }
-    let trimmed = field
+    let start = field
         .iter()
-        .copied()
-        .skip_while(|byte| matches!(byte, 0 | b' '))
-        .take_while(u8::is_ascii_digit)
-        .collect::<Vec<_>>();
-    if trimmed.is_empty() {
-        return Ok(0);
-    }
-    if trimmed.iter().any(|byte| !(b'0'..=b'7').contains(byte)) {
+        .position(|byte| *byte != b' ')
+        .unwrap_or(field.len());
+    let digits = field[start..]
+        .iter()
+        .position(|byte| !byte.is_ascii_digit())
+        .unwrap_or(field.len() - start);
+    let end = start + digits;
+    if field[end..].iter().any(|byte| !matches!(byte, 0 | b' '))
+        || field[start..end]
+            .iter()
+            .any(|byte| !(b'0'..=b'7').contains(byte))
+    {
         return Err(invalid("invalid octal numeric field"));
     }
-    trimmed.into_iter().try_fold(0_u64, |value, byte| {
+    field[start..end].iter().try_fold(0_u64, |value, byte| {
         value
             .checked_mul(8)
-            .and_then(|v| v.checked_add(u64::from(byte - b'0')))
+            .and_then(|v| v.checked_add(u64::from(*byte - b'0')))
             .ok_or_else(|| invalid("numeric field overflow"))
     })
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -176,7 +176,7 @@ pub(super) fn apply_pax_header(header: &mut Header, pax: &[(String, Vec<u8>)]) -
         header.path = path.to_vec();
     }
     if let Some(link) = pax_value(pax, "linkpath") {
-        header.link_name = Some(link.to_vec());
+        header.link_name = (!link.is_empty()).then(|| link.to_vec());
     }
     if let Some(size) = pax_u64_checked(pax, "size")? {
         header.stored_size = size;

--- a/src/format.rs
+++ b/src/format.rs
@@ -4,6 +4,13 @@ use std::path::Path;
 #[cfg(not(unix))]
 use std::path::PathBuf;
 
+pub(super) fn path_requires_directory(path: &[u8]) -> bool {
+    let last_component = path
+        .rsplit(|byte| *byte == b'/')
+        .find(|part| !part.is_empty());
+    path.ends_with(b"/") || matches!(last_component, Some(b"." | b".."))
+}
+
 pub(super) fn parse_header(block: &[u8; 512]) -> Result<Header> {
     let mut path = nul_bytes(&block[..100]).to_vec();
     let magic = &block[257..263];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,8 +294,14 @@ impl<R: Read> Archive<R> {
     ///
     /// # Errors
     ///
-    /// Reserved for reader initialization errors in future versions.
+    /// Returns an error if a previous iterator has consumed archive bytes.
     pub fn entries(&mut self) -> Result<Entries<'_, R>> {
+        if self.state.borrow().raw_bytes != 0 {
+            return Err(error(
+                ErrorKind::InvalidInput,
+                "cannot restart entry iteration after consuming archive bytes",
+            ));
+        }
         Ok(Entries {
             state: Rc::clone(&self.state),
             done: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod unpack;
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::marker::PhantomData;
@@ -31,6 +31,24 @@ use unpack::{ProgressReporter, unpack_archive};
 const BLOCK: u64 = 512;
 const MAX_METADATA_SIZE: u64 = 1024 * 1024;
 const MAX_SPARSE_SEGMENTS: usize = 1_000_000;
+const PAX_HEADER_KEYS: [&str; 7] = ["path", "linkpath", "size", "mode", "uid", "gid", "mtime"];
+type PaxRecords = Vec<(String, Vec<u8>)>;
+
+struct PaxLayer {
+    parent: Option<Rc<Self>>,
+    records: BTreeMap<String, Vec<u8>>,
+}
+
+impl Drop for PaxLayer {
+    fn drop(&mut self) {
+        // Retained entries can keep a long update chain alive. Release uniquely
+        // owned ancestors iteratively rather than recursively dropping it.
+        let mut parent = self.parent.take();
+        while let Some(mut layer) = parent {
+            parent = Rc::get_mut(&mut layer).and_then(|layer| layer.parent.take());
+        }
+    }
+}
 
 /// The crate's result type.
 pub type Result<T> = io::Result<T>;
@@ -284,6 +302,7 @@ impl<R: Read> Archive<R> {
             zero_blocks: 0,
             global_pax: BTreeMap::new(),
             pending_global_pax_bytes: 0,
+            global_pax_snapshot: None,
             local_pax: None,
             long_name: None,
             long_link: None,
@@ -313,6 +332,7 @@ pub struct Entries<'a, R: Read> {
     zero_blocks: u8,
     global_pax: BTreeMap<String, Vec<u8>>,
     pending_global_pax_bytes: u64,
+    global_pax_snapshot: Option<Rc<PaxLayer>>,
     local_pax: Option<Vec<(String, Vec<u8>)>>,
     long_name: Option<Vec<u8>>,
     long_link: Option<Vec<u8>>,
@@ -421,12 +441,21 @@ impl<R: Read> Entries<'_, R> {
                         {
                             return Err(invalid("GNU sparse PAX metadata is not valid globally"));
                         }
-                        for (key, value) in records {
+                        for (key, value) in &records {
                             if value.is_empty() {
-                                self.global_pax.remove(&key);
+                                self.global_pax.remove(key);
                             } else {
-                                self.global_pax.insert(key, value);
+                                self.global_pax.insert(key.clone(), value.clone());
                             }
+                        }
+                        if let Some(layer) = self.global_pax_snapshot.as_mut().and_then(Rc::get_mut)
+                        {
+                            layer.records.extend(records);
+                        } else {
+                            self.global_pax_snapshot = Some(Rc::new(PaxLayer {
+                                parent: self.global_pax_snapshot.take(),
+                                records: records.into_iter().collect(),
+                            }));
                         }
                     }
                     b'L' => self.long_name = Some(trim_metadata(payload)),
@@ -436,15 +465,42 @@ impl<R: Read> Entries<'_, R> {
                 continue;
             }
 
-            let mut pax: Vec<(String, Vec<u8>)> = self
-                .global_pax
+            let pax_global = self.global_pax_snapshot.clone();
+            let mut pax_local = self.local_pax.take().unwrap_or_default();
+            let pax_local_keys = pax_local
                 .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect();
-            if let Some(local) = self.local_pax.take() {
-                pax.retain(|(existing, _)| !local.iter().any(|(key, _)| key == existing));
-                pax.extend(local.into_iter().filter(|(_, value)| !value.is_empty()));
+                .map(|(key, _)| key.clone())
+                .collect::<BTreeSet<_>>();
+            pax_local.retain(|(_, value)| !value.is_empty());
+
+            // Resolve only fields used by header/sparse interpretation. Other
+            // global records remain shared until a caller requests them.
+            let mut pax = Vec::new();
+            for key in PAX_HEADER_KEYS {
+                if let Some(value) = self
+                    .global_pax
+                    .get(key)
+                    .filter(|_| !pax_local_keys.contains(key))
+                {
+                    pax.push((key.to_owned(), value.clone()));
+                }
             }
+            for (key, value) in self.global_pax.range("GNU.sparse.".to_owned()..) {
+                if !key.starts_with("GNU.sparse.") {
+                    break;
+                }
+                if !pax_local_keys.contains(key) {
+                    pax.push((key.clone(), value.clone()));
+                }
+            }
+            pax.extend(
+                pax_local
+                    .iter()
+                    .filter(|(key, _)| {
+                        PAX_HEADER_KEYS.contains(&key.as_str()) || key.starts_with("GNU.sparse.")
+                    })
+                    .cloned(),
+            );
             if let Some(name) = self.long_name.take() {
                 header.path = name;
             }
@@ -491,7 +547,9 @@ impl<R: Read> Entries<'_, R> {
                 state: Rc::clone(&self.state),
                 header,
                 kind,
-                pax,
+                pax_global,
+                pax_local,
+                pax_local_keys,
                 sparse,
                 logical_size,
                 logical_pos: 0,
@@ -662,7 +720,9 @@ pub struct Entry<R: Read> {
     state: Rc<RefCell<ReaderState<R>>>,
     header: Header,
     kind: EntryType,
-    pax: Vec<(String, Vec<u8>)>,
+    pax_global: Option<Rc<PaxLayer>>,
+    pax_local: PaxRecords,
+    pax_local_keys: BTreeSet<String>,
     sparse: Option<Vec<SparseSegment>>,
     logical_size: u64,
     logical_pos: u64,
@@ -701,9 +761,28 @@ impl<R: Read> Entry<R> {
     }
     /// Iterates over effective PAX key/value records.
     pub fn pax_extensions(&self) -> impl Iterator<Item = (&str, &[u8])> {
-        self.pax
-            .iter()
-            .map(|(key, value)| (key.as_str(), value.as_slice()))
+        let mut layers = Vec::new();
+        let mut layer = self.pax_global.as_deref();
+        while let Some(current) = layer {
+            layers.push(current);
+            layer = current.parent.as_deref();
+        }
+        let mut global = BTreeMap::new();
+        for layer in layers.into_iter().rev() {
+            for (key, value) in &layer.records {
+                if value.is_empty() {
+                    global.remove(key.as_str());
+                } else {
+                    global.insert(key.as_str(), value.as_slice());
+                }
+            }
+        }
+        global.retain(|key, _| !self.pax_local_keys.contains(*key));
+        global.into_iter().chain(
+            self.pax_local
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_slice())),
+        )
     }
     /// Returns cumulative raw bytes consumed from the underlying stream.
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,7 +533,15 @@ impl<R: Read> Entries<'_, R> {
             }
         }
         let mut extended = block[482] != 0;
+        // Include the inline descriptors and each full continuation block.
+        let mut metadata_bytes = 96_u64;
         while extended {
+            metadata_bytes = metadata_bytes
+                .checked_add(BLOCK)
+                .ok_or_else(|| invalid("old GNU sparse metadata size overflow"))?;
+            if metadata_bytes > MAX_METADATA_SIZE {
+                return Err(invalid("old GNU sparse metadata exceeds 1 MiB limit"));
+            }
             let mut ext = [0_u8; 512];
             self.state.borrow_mut().read_exact_counted(&mut ext)?;
             for chunk in ext[..504].chunks_exact(24) {
@@ -622,6 +630,9 @@ impl<R: Read> Entries<'_, R> {
     fn read_sparse_line(&self, consumed: &mut u64) -> Result<u64> {
         let mut digits = Vec::with_capacity(20);
         loop {
+            if *consumed >= MAX_METADATA_SIZE {
+                return Err(invalid("GNU sparse 1.0 metadata exceeds 1 MiB limit"));
+            }
             let mut byte = [0_u8; 1];
             let mut state = self.state.borrow_mut();
             if state.pending == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,6 +566,7 @@ impl<R: Read> Entries<'_, R> {
                 logical_pos: 0,
                 sparse_index: 0,
                 generation,
+                extraction_started: false,
             }));
         }
     }
@@ -739,6 +740,7 @@ pub struct Entry<R: Read> {
     logical_pos: u64,
     sparse_index: usize,
     generation: u64,
+    extraction_started: bool,
 }
 
 impl<R: Read> Entry<R> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,11 @@ impl<R: Read> Entries<'_, R> {
                 }
                 continue;
             }
+            if self.zero_blocks != 0 {
+                return Err(invalid(
+                    "tar zero block was not followed by a second zero block",
+                ));
+            }
             self.zero_blocks = 0;
             verify_checksum(&block)?;
             let mut header = parse_header(&block)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,6 +573,20 @@ impl<R: Read> Entries<'_, R> {
                 ));
             }
             let kind = EntryType::from_flag(flag);
+            if header.path.is_empty() {
+                return Err(invalid("tar entry has an empty effective path"));
+            }
+            if header.path.contains(&0) {
+                return Err(invalid("tar entry path contains a NUL byte"));
+            }
+            if matches!(kind, EntryType::Symlink | EntryType::Hardlink)
+                && header
+                    .link_name
+                    .as_ref()
+                    .is_none_or(|target| target.is_empty() || target.contains(&0))
+            {
+                return Err(invalid("tar link entry has an empty or NUL-bearing target"));
+            }
             self.pending_global_pax_bytes = 0;
             return Ok(Some(Entry {
                 state: Rc::clone(&self.state),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,23 +512,27 @@ impl<R: Read> Entries<'_, R> {
                     })
                     .cloned(),
             );
-            if self.long_name.is_some() && pax_value(&pax, "path").is_some() {
+            if self.long_name.is_some()
+                && pax_value(&pax, "path").is_some_and(|path| !path.is_empty())
+            {
                 return Err(invalid(
                     "PAX path and GNU long-name describe the same entry",
                 ));
             }
-            if self.long_link.is_some() && pax_value(&pax, "linkpath").is_some() {
+            if self.long_link.is_some()
+                && pax_value(&pax, "linkpath").is_some_and(|link| !link.is_empty())
+            {
                 return Err(invalid(
                     "PAX linkpath and GNU long-link describe the same entry",
                 ));
             }
+            apply_pax_header(&mut header, &pax)?;
             if let Some(name) = self.long_name.take() {
                 header.path = name;
             }
             if let Some(link) = self.long_link.take() {
                 header.link_name = Some(link);
             }
-            apply_pax_header(&mut header, &pax)?;
 
             // GNU sparse PAX archives use the tar header's size for the packed
             // body. Some writers (notably Go's archive/tar) also emit a PAX
@@ -569,6 +573,7 @@ impl<R: Read> Entries<'_, R> {
             }
             if matches!(flag, b'1' | b'2')
                 && pax_value(&pax, "linkpath").is_some_and(<[u8]>::is_empty)
+                && header.link_name.as_ref().is_none_or(Vec::is_empty)
             {
                 return Err(invalid(
                     "PAX linkpath deletion leaves link without a target",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,6 +675,20 @@ impl<R: Read> Entries<'_, R> {
         let major = pax_text_checked(pax, "GNU.sparse.major")?;
         let minor = pax_text_checked(pax, "GNU.sparse.minor")?;
         if major == Some("1") && minor == Some("0") {
+            if pax.iter().any(|(key, _)| {
+                matches!(
+                    key.as_str(),
+                    "GNU.sparse.map"
+                        | "GNU.sparse.numblocks"
+                        | "GNU.sparse.offset"
+                        | "GNU.sparse.numbytes"
+                        | "GNU.sparse.size"
+                )
+            }) {
+                return Err(invalid(
+                    "GNU sparse 1.0 metadata mixes sparse representations",
+                ));
+            }
             let logical = pax_u64_checked(pax, "GNU.sparse.realsize")?
                 .ok_or_else(|| invalid("PAX sparse 1.0 lacks GNU.sparse.realsize"))?;
             let (map, map_bytes) = self.read_sparse_1_0_map()?;
@@ -694,7 +708,19 @@ impl<R: Read> Entries<'_, R> {
             .or(pax_u64_checked(pax, "GNU.sparse.realsize")?)
             .ok_or_else(|| invalid("GNU sparse PAX metadata lacks logical size"))?;
         let map = if let Some(value) = pax_text_checked(pax, "GNU.sparse.map")? {
-            parse_sparse_csv(value)?
+            if pax
+                .iter()
+                .any(|(key, _)| matches!(key.as_str(), "GNU.sparse.offset" | "GNU.sparse.numbytes"))
+            {
+                return Err(invalid("GNU sparse PAX metadata mixes maps and pairs"));
+            }
+            let map = parse_sparse_csv(value)?;
+            if pax_u64_checked(pax, "GNU.sparse.numblocks")?
+                .is_some_and(|count| usize::try_from(count).ok() != Some(map.len()))
+            {
+                return Err(invalid("GNU sparse PAX map count does not match"));
+            }
+            map
         } else if let Some(count) = pax_u64_checked(pax, "GNU.sparse.numblocks")? {
             parse_sparse_pairs(pax, count)?
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,7 +468,7 @@ impl<R: Read> Entries<'_, R> {
             }
 
             let pax_global = self.global_pax_snapshot.clone();
-            let mut pax_local = self.local_pax.take().unwrap_or_default();
+            let pax_local = self.local_pax.take().unwrap_or_default();
             let pax_local_keys = pax_local
                 .iter()
                 .map(|(key, _)| key.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,6 +533,7 @@ impl<R: Read> Entries<'_, R> {
             // GNU sparse PAX archives use the tar header's size for the packed
             // body. Some writers (notably Go's archive/tar) also emit a PAX
             // `size` record containing the logical sparse size.
+            let pax_size = header.stored_size;
             let has_pax_sparse = pax.iter().any(|(key, _)| key.starts_with("GNU.sparse."));
             if has_pax_sparse && !matches!(flag, 0 | b'0' | b'7') {
                 return Err(invalid("GNU sparse PAX metadata requires a regular file"));
@@ -540,7 +541,7 @@ impl<R: Read> Entries<'_, R> {
             let physical_size = if has_pax_sparse {
                 size
             } else {
-                header.stored_size
+                pax_size
             };
             if matches!(flag, b'1'..=b'6') && (size != 0 || physical_size != 0) {
                 return Err(invalid("nonregular tar entry cannot carry payload"));
@@ -559,6 +560,11 @@ impl<R: Read> Entries<'_, R> {
             } else {
                 self.parse_pax_sparse(&pax, physical_size)?
             };
+            if has_pax_sparse && pax_size != physical_size && pax_size != logical_size {
+                return Err(invalid(
+                    "GNU sparse PAX size conflicts with physical and logical sizes",
+                ));
+            }
             if let Some(name) = pax_value(&pax, "GNU.sparse.name") {
                 header.path = name.to_vec();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -608,7 +608,7 @@ impl<R: Read> Entries<'_, R> {
         if count > MAX_SPARSE_SEGMENTS {
             return Err(invalid("sparse map has too many segments"));
         }
-        let mut map = Vec::with_capacity(count);
+        let mut map = Vec::new();
         for _ in 0..count {
             let offset = self.read_sparse_line(&mut consumed)?;
             let len = self.read_sparse_line(&mut consumed)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,11 +427,18 @@ impl<R: Read> Entries<'_, R> {
             // GNU sparse PAX archives use the tar header's size for the packed
             // body. Some writers (notably Go's archive/tar) also emit a PAX
             // `size` record containing the logical sparse size.
-            let physical_size = if pax.iter().any(|(key, _)| key.starts_with("GNU.sparse.")) {
+            let has_pax_sparse = pax.iter().any(|(key, _)| key.starts_with("GNU.sparse."));
+            if has_pax_sparse && !matches!(flag, 0 | b'0' | b'7') {
+                return Err(invalid("GNU sparse PAX metadata requires a regular file"));
+            }
+            let physical_size = if has_pax_sparse {
                 size
             } else {
                 header.stored_size
             };
+            if matches!(flag, b'1'..=b'6') && (size != 0 || physical_size != 0) {
+                return Err(invalid("nonregular tar entry cannot carry payload"));
+            }
             header.stored_size = physical_size;
             let generation;
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,18 @@ impl<R: Read> Entries<'_, R> {
             let flag = header.type_flag;
             let size = header.stored_size;
 
+            let identity = &block[257..265];
+            let is_ustar = identity == b"ustar\x0000";
+            let is_gnu = identity == b"ustar  \0";
+            if matches!(flag, b'x' | b'g') && !is_ustar {
+                return Err(invalid("PAX extension requires a USTAR carrier"));
+            }
+            if matches!(flag, b'L' | b'K') && !(is_ustar || is_gnu) {
+                return Err(invalid(
+                    "GNU long-name/link extension requires a USTAR or GNU carrier",
+                ));
+            }
+
             if matches!(flag, b'x' | b'g' | b'L' | b'K') {
                 if size > MAX_METADATA_SIZE {
                     return Err(error(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -838,6 +838,12 @@ impl<R: Read> Read for Entry<R> {
         if buf.is_empty() || self.logical_pos >= self.logical_size {
             return Ok(0);
         }
+        if self.generation != self.state.borrow().generation {
+            return Err(error(
+                ErrorKind::InvalidInput,
+                "entry is stale because iteration advanced",
+            ));
+        }
         let remaining = self.logical_size - self.logical_pos;
         let limit = usize::try_from(remaining.min(buf.len() as u64)).unwrap_or(buf.len());
         let Some(map) = self.sparse.as_ref() else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -460,8 +460,18 @@ impl<R: Read> Entries<'_, R> {
                             }));
                         }
                     }
-                    b'L' => self.long_name = Some(trim_metadata(payload)),
-                    b'K' => self.long_link = Some(trim_metadata(payload)),
+                    b'L' => {
+                        if self.long_name.is_some() {
+                            return Err(invalid("two GNU long-name headers describe one entry"));
+                        }
+                        self.long_name = Some(trim_metadata(payload));
+                    }
+                    b'K' => {
+                        if self.long_link.is_some() {
+                            return Err(invalid("two GNU long-link headers describe one entry"));
+                        }
+                        self.long_link = Some(trim_metadata(payload));
+                    }
                     _ => unreachable!(),
                 }
                 continue;
@@ -502,6 +512,16 @@ impl<R: Read> Entries<'_, R> {
                     })
                     .cloned(),
             );
+            if self.long_name.is_some() && pax_value(&pax, "path").is_some() {
+                return Err(invalid(
+                    "PAX path and GNU long-name describe the same entry",
+                ));
+            }
+            if self.long_link.is_some() && pax_value(&pax, "linkpath").is_some() {
+                return Err(invalid(
+                    "PAX linkpath and GNU long-link describe the same entry",
+                ));
+            }
             if let Some(name) = self.long_name.take() {
                 header.path = name;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -900,7 +900,7 @@ impl<R: Read> Entry<R> {
                 }
                 file.write_all(&buf[..n])?;
                 remaining -= n as u64;
-                progress.update(self.bytes_read());
+                progress.update(self.bytes_read())?;
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ impl<R: Read> Entries<'_, R> {
                 let mut first = [0_u8; 1];
                 let n = state.read_counted(&mut first)?;
                 if n == 0 {
-                    return Ok(None);
+                    return self.finish_stream();
                 }
                 block[0] = first[0];
                 state.read_exact_counted(&mut block[1..])?;
@@ -358,7 +358,7 @@ impl<R: Read> Entries<'_, R> {
             if block.iter().all(|byte| *byte == 0) {
                 self.zero_blocks += 1;
                 if self.zero_blocks == 2 {
-                    return Ok(None);
+                    return self.finish_stream();
                 }
                 continue;
             }
@@ -474,6 +474,13 @@ impl<R: Read> Entries<'_, R> {
                 generation,
             }));
         }
+    }
+
+    fn finish_stream(&self) -> Result<Option<Entry<R>>> {
+        if self.local_pax.is_some() || self.long_name.is_some() || self.long_link.is_some() {
+            return Err(invalid("extension entry was not followed by a member"));
+        }
+        Ok(None)
     }
 
     fn read_metadata(&self, size: u64) -> Result<Vec<u8>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,7 @@ impl<R: Read> Archive<R> {
             done: false,
             zero_blocks: 0,
             global_pax: BTreeMap::new(),
+            pending_global_pax_bytes: 0,
             local_pax: None,
             long_name: None,
             long_link: None,
@@ -311,6 +312,7 @@ pub struct Entries<'a, R: Read> {
     done: bool,
     zero_blocks: u8,
     global_pax: BTreeMap<String, Vec<u8>>,
+    pending_global_pax_bytes: u64,
     local_pax: Option<Vec<(String, Vec<u8>)>>,
     long_name: Option<Vec<u8>>,
     long_link: Option<Vec<u8>>,
@@ -391,6 +393,16 @@ impl<R: Read> Entries<'_, R> {
                         ErrorKind::InvalidData,
                         "tar metadata exceeds 1 MiB limit",
                     ));
+                }
+                if flag == b'g' {
+                    let total = self
+                        .pending_global_pax_bytes
+                        .checked_add(size)
+                        .ok_or_else(|| invalid("global PAX metadata size overflow"))?;
+                    if total > MAX_METADATA_SIZE {
+                        return Err(invalid("pending global PAX metadata exceeds 1 MiB limit"));
+                    }
+                    self.pending_global_pax_bytes = total;
                 }
                 let payload = self.read_metadata(size)?;
                 match flag {
@@ -474,6 +486,7 @@ impl<R: Read> Entries<'_, R> {
                 header.path = name.to_vec();
             }
             let kind = EntryType::from_flag(flag);
+            self.pending_global_pax_bytes = 0;
             return Ok(Some(Entry {
                 state: Rc::clone(&self.state),
                 header,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,11 +538,7 @@ impl<R: Read> Entries<'_, R> {
             if has_pax_sparse && !matches!(flag, 0 | b'0' | b'7') {
                 return Err(invalid("GNU sparse PAX metadata requires a regular file"));
             }
-            let physical_size = if has_pax_sparse {
-                size
-            } else {
-                pax_size
-            };
+            let physical_size = if has_pax_sparse { size } else { pax_size };
             if matches!(flag, b'1'..=b'6') && (size != 0 || physical_size != 0) {
                 return Err(invalid("nonregular tar entry cannot carry payload"));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,15 @@ impl<R: Read> Entries<'_, R> {
                         self.local_pax = Some(parse_pax(&payload)?);
                     }
                     b'g' => {
-                        for (key, value) in parse_pax(&payload)? {
+                        let records = parse_pax(&payload)?;
+                        // Sparse metadata describes one member, not an inherited default.
+                        if records
+                            .iter()
+                            .any(|(key, _)| key.starts_with("GNU.sparse."))
+                        {
+                            return Err(invalid("GNU sparse PAX metadata is not valid globally"));
+                        }
+                        for (key, value) in records {
                             if value.is_empty() {
                                 self.global_pax.remove(&key);
                             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,11 +442,7 @@ impl<R: Read> Entries<'_, R> {
                             return Err(invalid("GNU sparse PAX metadata is not valid globally"));
                         }
                         for (key, value) in &records {
-                            if value.is_empty() {
-                                self.global_pax.remove(key);
-                            } else {
-                                self.global_pax.insert(key.clone(), value.clone());
-                            }
+                            self.global_pax.insert(key.clone(), value.clone());
                         }
                         if let Some(layer) = self.global_pax_snapshot.as_mut().and_then(Rc::get_mut)
                         {
@@ -471,7 +467,6 @@ impl<R: Read> Entries<'_, R> {
                 .iter()
                 .map(|(key, _)| key.clone())
                 .collect::<BTreeSet<_>>();
-            pax_local.retain(|(_, value)| !value.is_empty());
 
             // Resolve only fields used by header/sparse interpretation. Other
             // global records remain shared until a caller requests them.
@@ -540,6 +535,16 @@ impl<R: Read> Entries<'_, R> {
             };
             if let Some(name) = pax_value(&pax, "GNU.sparse.name") {
                 header.path = name.to_vec();
+            }
+            if header.path.is_empty() && pax_value(&pax, "path").is_some_and(<[u8]>::is_empty) {
+                return Err(invalid("PAX path deletion leaves entry without a path"));
+            }
+            if matches!(flag, b'1' | b'2')
+                && pax_value(&pax, "linkpath").is_some_and(<[u8]>::is_empty)
+            {
+                return Err(invalid(
+                    "PAX linkpath deletion leaves link without a target",
+                ));
             }
             let kind = EntryType::from_flag(flag);
             self.pending_global_pax_bytes = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,8 +704,18 @@ impl<R: Read> Entries<'_, R> {
                 "unsupported or contradictory GNU sparse PAX version",
             ));
         }
-        let logical = pax_u64_checked(pax, "GNU.sparse.size")?
-            .or(pax_u64_checked(pax, "GNU.sparse.realsize")?)
+        let size = pax_u64_checked(pax, "GNU.sparse.size")?;
+        let realsize = pax_u64_checked(pax, "GNU.sparse.realsize")?;
+        if size
+            .zip(realsize)
+            .is_some_and(|(size, realsize)| size != realsize)
+        {
+            return Err(invalid(
+                "GNU sparse PAX metadata has conflicting logical sizes",
+            ));
+        }
+        let logical = size
+            .or(realsize)
             .ok_or_else(|| invalid("GNU sparse PAX metadata lacks logical size"))?;
         let map = if let Some(value) = pax_text_checked(pax, "GNU.sparse.map")? {
             if pax

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -126,6 +126,7 @@ pub(super) struct DeferredDirectory {
 
 impl DeferredDirectory {
     fn new(path: PathBuf, mode: u32, mtime: i64) -> Result<Self> {
+        let path = fs::canonicalize(path)?;
         let metadata = fs::symlink_metadata(&path)?;
         if !metadata.is_dir() {
             return Err(invalid("archive directory is not a directory"));
@@ -373,7 +374,7 @@ pub(super) fn unpack_archive<R: Read>(
                 )?);
                 summary.dirs += 1;
             }
-            EntryType::File | EntryType::Other(_) => {
+            EntryType::File => {
                 if !prepare_output(&output, opts.overwrite)? {
                     summary.skipped.push(SkippedEntry {
                         path: original,
@@ -582,7 +583,7 @@ pub(super) fn unpack_entry<R: Read>(
             )?);
             summary.dirs = 1;
         }
-        EntryType::File | EntryType::Other(_) => {
+        EntryType::File => {
             if !prepare_output(&output, opts.overwrite)? {
                 summary.skipped.push(SkippedEntry {
                     path: original,

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -111,6 +111,7 @@ impl Default for UnpackOptions {
 #[must_use = "call finish() to apply deferred directory metadata"]
 pub struct EntryUnpacker<'a> {
     root: PathBuf,
+    root_identity: RootIdentity,
     opts: &'a mut UnpackOptions,
     deferred_dirs: Vec<DeferredDirectory>,
 }
@@ -139,6 +140,38 @@ impl DeferredDirectory {
     }
 }
 
+pub(super) struct RootIdentity {
+    #[cfg(unix)]
+    identity: (u64, u64),
+}
+
+impl RootIdentity {
+    fn capture(root: &Path) -> Result<Self> {
+        let metadata = fs::symlink_metadata(root)?;
+        if !metadata.is_dir() {
+            return Err(invalid("extraction root is not a directory"));
+        }
+        Ok(Self {
+            #[cfg(unix)]
+            identity: (metadata.dev(), metadata.ino()),
+        })
+    }
+
+    fn check(&self, root: &Path) -> Result<()> {
+        #[cfg(not(unix))]
+        let _ = self;
+        let metadata = fs::symlink_metadata(root)?;
+        #[cfg(unix)]
+        let identity_matches = (metadata.dev(), metadata.ino()) == self.identity;
+        #[cfg(not(unix))]
+        let identity_matches = true;
+        if !metadata.is_dir() || !identity_matches || fs::canonicalize(root)?.as_path() != root {
+            return Err(invalid("extraction root changed during unpack"));
+        }
+        Ok(())
+    }
+}
+
 impl<'a> EntryUnpacker<'a> {
     /// Creates a per-entry extractor rooted at `dest`.
     ///
@@ -152,8 +185,11 @@ impl<'a> EntryUnpacker<'a> {
         if fs::symlink_metadata(dest)?.file_type().is_symlink() {
             return Err(invalid("destination may not be a symlink"));
         }
+        let root = fs::canonicalize(dest)?;
+        let root_identity = RootIdentity::capture(&root)?;
         Ok(Self {
-            root: fs::canonicalize(dest)?,
+            root,
+            root_identity,
             opts,
             deferred_dirs: Vec::new(),
         })
@@ -171,7 +207,13 @@ impl<'a> EntryUnpacker<'a> {
     /// data, callback-independent I/O failure, or filesystem extraction
     /// failure, or if the entry is stale, already read, or previously extracted.
     pub fn unpack<R: Read>(&mut self, entry: &mut Entry<R>) -> Result<UnpackSummary> {
-        unpack_entry(entry, &self.root, self.opts, &mut self.deferred_dirs)
+        unpack_entry(
+            entry,
+            &self.root,
+            &self.root_identity,
+            self.opts,
+            &mut self.deferred_dirs,
+        )
     }
 
     /// Applies deferred directory metadata and completes extraction.
@@ -181,6 +223,7 @@ impl<'a> EntryUnpacker<'a> {
     /// Returns an error when directory permissions or modification times
     /// cannot be restored.
     pub fn finish(self) -> Result<()> {
+        self.root_identity.check(&self.root)?;
         apply_deferred_directory_metadata(
             self.deferred_dirs,
             self.opts.preserve_permissions,
@@ -192,24 +235,30 @@ impl<'a> EntryUnpacker<'a> {
 pub(super) struct ProgressReporter<'a> {
     callback: &'a mut Option<ProgressCallback>,
     last: u64,
+    root_guard: Option<(&'a Path, &'a RootIdentity)>,
 }
 
 impl ProgressReporter<'_> {
-    pub(super) fn update(&mut self, current: u64) {
+    pub(super) fn update(&mut self, current: u64) -> Result<()> {
         if current.saturating_sub(self.last) >= 64 * 1024 {
-            self.fire(current);
+            self.fire(current)?;
         }
+        Ok(())
     }
-    fn boundary(&mut self, current: u64) {
-        self.fire(current);
+    fn boundary(&mut self, current: u64) -> Result<()> {
+        self.fire(current)
     }
-    fn fire(&mut self, current: u64) {
+    fn fire(&mut self, current: u64) -> Result<()> {
         if let Some(callback) = self.callback.as_mut() {
             callback(Progress {
                 bytes_read: current,
             });
+            if let Some((root, identity)) = self.root_guard {
+                identity.check(root)?;
+            }
         }
         self.last = current;
+        Ok(())
     }
 }
 
@@ -225,6 +274,7 @@ pub(super) fn unpack_archive<R: Read>(
         return Err(invalid("destination may not be a symlink"));
     }
     let root = fs::canonicalize(dest)?;
+    let root_identity = RootIdentity::capture(&root)?;
     let mut summary = UnpackSummary::default();
     let mut deferred_dirs = Vec::new();
     let preserve_permissions = opts.preserve_permissions;
@@ -232,10 +282,12 @@ pub(super) fn unpack_archive<R: Read>(
     let mut progress = ProgressReporter {
         callback: &mut opts.on_progress,
         last: 0,
+        root_guard: Some((&root, &root_identity)),
     };
     for item in &mut entries {
         let mut entry = item?;
         validate_directory_suffixes(&entry)?;
+        root_identity.check(&root)?;
         let original = entry.path()?.into_owned();
         if let Some(callback) = opts.on_entry.as_mut() {
             callback(&EntryInfo {
@@ -244,8 +296,9 @@ pub(super) fn unpack_archive<R: Read>(
                 size: entry.logical_size,
                 sparse: entry.sparse.is_some(),
             });
+            root_identity.check(&root)?;
         }
-        progress.boundary(entry.bytes_read());
+        progress.boundary(entry.bytes_read())?;
         let Some(relative) = secure_relative_path(&original, opts.strip_components)? else {
             summary.skipped.push(SkippedEntry {
                 path: original,
@@ -343,9 +396,10 @@ pub(super) fn unpack_archive<R: Read>(
                             break;
                         }
                         file.write_all(&buf[..n])?;
-                        progress.update(entry.bytes_read());
+                        progress.update(entry.bytes_read())?;
                     }
                 }
+                root_identity.check(&root)?;
                 apply_file_metadata(
                     &file,
                     entry.header.mode,
@@ -406,10 +460,11 @@ pub(super) fn unpack_archive<R: Read>(
                 reason: SkipReason::UnsupportedType,
             }),
         }
-        progress.boundary(entry.bytes_read());
+        progress.boundary(entry.bytes_read())?;
     }
+    root_identity.check(&root)?;
     apply_deferred_directory_metadata(deferred_dirs, preserve_permissions, preserve_mtime)?;
-    progress.boundary(archive.state.borrow().raw_bytes);
+    progress.boundary(archive.state.borrow().raw_bytes)?;
     Ok(summary)
 }
 
@@ -417,6 +472,7 @@ pub(super) fn unpack_archive<R: Read>(
 pub(super) fn unpack_entry<R: Read>(
     entry: &mut Entry<R>,
     root: &Path,
+    root_identity: &RootIdentity,
     opts: &mut UnpackOptions,
     deferred_dirs: &mut Vec<DeferredDirectory>,
 ) -> Result<UnpackSummary> {
@@ -433,6 +489,7 @@ pub(super) fn unpack_entry<R: Read>(
         ));
     }
     validate_directory_suffixes(entry)?;
+    root_identity.check(root)?;
     let original = entry.path()?.into_owned();
     if let Some(callback) = opts.on_entry.as_mut() {
         callback(&EntryInfo {
@@ -441,13 +498,15 @@ pub(super) fn unpack_entry<R: Read>(
             size: entry.logical_size,
             sparse: entry.sparse.is_some(),
         });
+        root_identity.check(root)?;
     }
     let mut summary = UnpackSummary::default();
     let mut progress = ProgressReporter {
         callback: &mut opts.on_progress,
         last: 0,
+        root_guard: Some((root, root_identity)),
     };
-    progress.boundary(entry.bytes_read());
+    progress.boundary(entry.bytes_read())?;
     let Some(relative) = secure_relative_path(&original, opts.strip_components)? else {
         summary.skipped.push(SkippedEntry {
             path: original,
@@ -549,9 +608,10 @@ pub(super) fn unpack_entry<R: Read>(
                         break;
                     }
                     file.write_all(&buf[..n])?;
-                    progress.update(entry.bytes_read());
+                    progress.update(entry.bytes_read())?;
                 }
             }
+            root_identity.check(root)?;
             apply_file_metadata(
                 &file,
                 entry.header.mode,
@@ -616,7 +676,7 @@ pub(super) fn unpack_entry<R: Read>(
             reason: SkipReason::UnsupportedType,
         }),
     }
-    progress.boundary(entry.bytes_read());
+    progress.boundary(entry.bytes_read())?;
     Ok(summary)
 }
 
@@ -994,11 +1054,12 @@ mod tests {
         let mut reporter = ProgressReporter {
             callback: &mut callback,
             last: 0,
+            root_guard: None,
         };
-        reporter.update(64 * 1024 - 1);
+        reporter.update(64 * 1024 - 1).unwrap();
         assert!(seen.borrow().is_empty());
-        reporter.update(64 * 1024);
-        reporter.boundary(70 * 1024);
+        reporter.update(64 * 1024).unwrap();
+        reporter.boundary(70 * 1024).unwrap();
         assert_eq!(*seen.borrow(), [64 * 1024, 70 * 1024]);
     }
 

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -245,6 +245,25 @@ pub(super) fn unpack_archive<R: Read>(
             continue;
         }
         let output = root.join(&relative);
+        if entry.kind == EntryType::Hardlink
+            && skip_existing_output(&root, &relative, opts.overwrite)?
+        {
+            summary.skipped.push(SkippedEntry {
+                path: original,
+                reason: SkipReason::Exists,
+            });
+            continue;
+        }
+        let hardlink_source = if entry.kind == EntryType::Hardlink {
+            Some(preflight_hardlink_source(
+                &entry,
+                &root,
+                &output,
+                opts.strip_components,
+            )?)
+        } else {
+            None
+        };
         ensure_safe_parents(&root, &relative)?;
         match entry.kind {
             EntryType::Directory => {
@@ -331,19 +350,9 @@ pub(super) fn unpack_archive<R: Read>(
                     });
                     continue;
                 }
-                let target = entry
-                    .header
-                    .link_name()
-                    .ok_or_else(|| invalid("hardlink lacks target"))?;
-                let target_relative = secure_relative_path(&target, opts.strip_components)?
-                    .ok_or_else(|| invalid("hardlink target was stripped away"))?;
-                ensure_safe_parents(&root, &target_relative)?;
-                let source = root.join(target_relative);
-                let metadata = fs::symlink_metadata(&source)
-                    .map_err(|_| invalid("hardlink target does not exist within destination"))?;
-                if metadata.file_type().is_symlink() {
-                    return Err(invalid("hardlink target may not be a symlink"));
-                }
+                let source = hardlink_source
+                    .as_ref()
+                    .ok_or_else(|| invalid("hardlink source was not prepared"))?;
                 fs::hard_link(source, output)?;
                 summary.hardlinks += 1;
             }
@@ -419,6 +428,23 @@ pub(super) fn unpack_entry<R: Read>(
         return Ok(summary);
     }
     let output = root.join(&relative);
+    if entry.kind == EntryType::Hardlink && skip_existing_output(root, &relative, opts.overwrite)? {
+        summary.skipped.push(SkippedEntry {
+            path: original,
+            reason: SkipReason::Exists,
+        });
+        return Ok(summary);
+    }
+    let hardlink_source = if entry.kind == EntryType::Hardlink {
+        Some(preflight_hardlink_source(
+            entry,
+            root,
+            &output,
+            opts.strip_components,
+        )?)
+    } else {
+        None
+    };
     ensure_safe_parents(root, &relative)?;
     match entry.kind {
         EntryType::Directory => {
@@ -511,19 +537,9 @@ pub(super) fn unpack_entry<R: Read>(
                 return Ok(summary);
             }
             entry.extraction_started = true;
-            let target = entry
-                .header
-                .link_name()
-                .ok_or_else(|| invalid("hardlink lacks target"))?;
-            let target_relative = secure_relative_path(&target, opts.strip_components)?
-                .ok_or_else(|| invalid("hardlink target was stripped away"))?;
-            ensure_safe_parents(root, &target_relative)?;
-            let source = root.join(target_relative);
-            let metadata = fs::symlink_metadata(&source)
-                .map_err(|_| invalid("hardlink target does not exist within destination"))?;
-            if metadata.file_type().is_symlink() {
-                return Err(invalid("hardlink target may not be a symlink"));
-            }
+            let source = hardlink_source
+                .as_ref()
+                .ok_or_else(|| invalid("hardlink source was not prepared"))?;
             fs::hard_link(source, output)?;
             summary.hardlinks = 1;
         }
@@ -596,6 +612,65 @@ fn ensure_safe_parents(root: &Path, relative: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn preflight_hardlink_source<R: Read>(
+    entry: &Entry<R>,
+    root: &Path,
+    output: &Path,
+    strip_components: usize,
+) -> Result<PathBuf> {
+    let target = entry
+        .header
+        .link_name()
+        .ok_or_else(|| invalid("hardlink lacks target"))?;
+    let relative = secure_relative_path(&target, strip_components)?
+        .ok_or_else(|| invalid("hardlink target was stripped away"))?;
+    let mut source = root.to_path_buf();
+    if let Some(parent) = relative.parent() {
+        // A missing source is an error, never a reason to create its parents.
+        for component in parent.components() {
+            source.push(component);
+            let metadata = fs::symlink_metadata(&source)?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(invalid("hardlink target parent is not a safe directory"));
+            }
+        }
+    }
+    source = root.join(relative);
+    let metadata = fs::symlink_metadata(&source)?;
+    if !metadata.is_file() {
+        return Err(invalid("hardlink target must be an existing regular file"));
+    }
+    match fs::symlink_metadata(output) {
+        Ok(metadata) if !metadata.file_type().is_symlink() => {
+            // Distinct hard links to one inode are safe; the same pathname is
+            // not, including filesystem case and Unicode aliases.
+            if fs::canonicalize(output)? == fs::canonicalize(&source)? {
+                return Err(invalid("hardlink target resolves to its output path"));
+            }
+        }
+        Ok(_) => {}
+        Err(err) if err.kind() == ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
+    Ok(source)
+}
+
+fn skip_existing_output(root: &Path, relative: &Path, overwrite: bool) -> Result<bool> {
+    if overwrite {
+        return Ok(false);
+    }
+    match fs::symlink_metadata(root.join(relative)) {
+        Ok(_) => {
+            // An existing leaf does not authorize traversal through a symlinked
+            // parent. Its parents already exist, so this check creates none.
+            ensure_safe_parents(root, relative)?;
+            Ok(true)
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
 }
 
 fn prepare_output(path: &Path, overwrite: bool) -> Result<bool> {

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -198,6 +198,7 @@ pub(super) fn unpack_archive<R: Read>(
     dest: &Path,
     opts: &mut UnpackOptions,
 ) -> Result<UnpackSummary> {
+    let mut entries = archive.entries()?;
     fs::create_dir_all(dest)?;
     if fs::symlink_metadata(dest)?.file_type().is_symlink() {
         return Err(invalid("destination may not be a symlink"));
@@ -211,7 +212,6 @@ pub(super) fn unpack_archive<R: Read>(
         callback: &mut opts.on_progress,
         last: 0,
     };
-    let mut entries = archive.entries()?;
     for item in &mut entries {
         let mut entry = item?;
         validate_directory_suffixes(&entry)?;

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -2,6 +2,8 @@ use super::format::path_requires_directory;
 use super::{Archive, Entry, EntryType, Result, error, invalid};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::{Component, Path, PathBuf};
 
 /// Progress notification containing raw input bytes consumed.
@@ -110,7 +112,31 @@ impl Default for UnpackOptions {
 pub struct EntryUnpacker<'a> {
     root: PathBuf,
     opts: &'a mut UnpackOptions,
-    deferred_dirs: Vec<(PathBuf, u32, i64)>,
+    deferred_dirs: Vec<DeferredDirectory>,
+}
+
+pub(super) struct DeferredDirectory {
+    path: PathBuf,
+    mode: u32,
+    mtime: i64,
+    #[cfg(unix)]
+    identity: (u64, u64),
+}
+
+impl DeferredDirectory {
+    fn new(path: PathBuf, mode: u32, mtime: i64) -> Result<Self> {
+        let metadata = fs::symlink_metadata(&path)?;
+        if !metadata.is_dir() {
+            return Err(invalid("archive directory is not a directory"));
+        }
+        Ok(Self {
+            path,
+            mode,
+            mtime,
+            #[cfg(unix)]
+            identity: (metadata.dev(), metadata.ino()),
+        })
+    }
 }
 
 impl<'a> EntryUnpacker<'a> {
@@ -287,11 +313,11 @@ pub(super) fn unpack_archive<R: Read>(
                     return Err(invalid("archive directory collides with symlink"));
                 }
                 fs::create_dir_all(&output)?;
-                deferred_dirs.push((
-                    fs::canonicalize(output)?,
+                deferred_dirs.push(DeferredDirectory::new(
+                    output,
                     entry.header.mode,
                     entry.header.mtime,
-                ));
+                )?);
                 summary.dirs += 1;
             }
             EntryType::File | EntryType::Other(_) => {
@@ -320,8 +346,8 @@ pub(super) fn unpack_archive<R: Read>(
                         progress.update(entry.bytes_read());
                     }
                 }
-                apply_metadata(
-                    &output,
+                apply_file_metadata(
+                    &file,
                     entry.header.mode,
                     entry.header.mtime,
                     preserve_permissions,
@@ -392,7 +418,7 @@ pub(super) fn unpack_entry<R: Read>(
     entry: &mut Entry<R>,
     root: &Path,
     opts: &mut UnpackOptions,
-    deferred_dirs: &mut Vec<(PathBuf, u32, i64)>,
+    deferred_dirs: &mut Vec<DeferredDirectory>,
 ) -> Result<UnpackSummary> {
     if entry.generation != entry.state.borrow().generation {
         return Err(error(
@@ -490,11 +516,11 @@ pub(super) fn unpack_entry<R: Read>(
             }
             entry.extraction_started = true;
             fs::create_dir_all(&output)?;
-            deferred_dirs.push((
-                fs::canonicalize(output)?,
+            deferred_dirs.push(DeferredDirectory::new(
+                output,
                 entry.header.mode,
                 entry.header.mtime,
-            ));
+            )?);
             summary.dirs = 1;
         }
         EntryType::File | EntryType::Other(_) => {
@@ -526,8 +552,8 @@ pub(super) fn unpack_entry<R: Read>(
                     progress.update(entry.bytes_read());
                 }
             }
-            apply_metadata(
-                &output,
+            apply_file_metadata(
+                &file,
                 entry.header.mode,
                 entry.header.mtime,
                 opts.preserve_permissions,
@@ -782,26 +808,26 @@ fn prepare_output(path: &Path, overwrite: bool) -> Result<bool> {
 }
 
 fn apply_deferred_directory_metadata(
-    directories: Vec<(PathBuf, u32, i64)>,
+    directories: Vec<DeferredDirectory>,
     preserve_permissions: bool,
     preserve_mtime: bool,
 ) -> Result<()> {
     // Canonical paths coalesce case and Unicode aliases on filesystems that
     // resolve those spellings to the same directory. The last member wins.
     let mut latest = std::collections::BTreeMap::new();
-    for (path, mode, mtime) in directories {
-        latest.insert(path, (mode, mtime));
+    for directory in directories {
+        latest.insert(directory.path.clone(), directory);
     }
     let mut directories: Vec<_> = latest.into_iter().collect();
     directories.sort_by_key(|(path, _)| std::cmp::Reverse(path.components().count()));
-    for (path, (mode, mtime)) in directories {
-        apply_metadata(&path, mode, mtime, preserve_permissions, preserve_mtime)?;
+    for (_, directory) in directories {
+        apply_directory_metadata(&directory, preserve_permissions, preserve_mtime)?;
     }
     Ok(())
 }
 
-fn apply_metadata(
-    path: &Path,
+fn apply_file_metadata(
+    file: &fs::File,
     mode: u32,
     mtime: i64,
     preserve_permissions: bool,
@@ -812,11 +838,58 @@ fn apply_metadata(
     #[cfg(unix)]
     if preserve_permissions {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o7777))?;
+        file.set_permissions(fs::Permissions::from_mode(mode & 0o7777))?;
     }
     if preserve_mtime {
         let time = filetime::FileTime::from_unix_time(mtime, 0);
-        filetime::set_file_mtime(path, time)?;
+        filetime::set_file_handle_times(file, None, Some(time))?;
+    }
+    Ok(())
+}
+
+fn apply_directory_metadata(
+    directory: &DeferredDirectory,
+    preserve_permissions: bool,
+    preserve_mtime: bool,
+) -> Result<()> {
+    #[cfg(not(unix))]
+    let _ = directory.mode;
+    if !preserve_permissions && !preserve_mtime {
+        return Ok(());
+    }
+    #[cfg(unix)]
+    let metadata = {
+        let metadata = fs::symlink_metadata(&directory.path)?;
+        if !metadata.is_dir() || (metadata.dev(), metadata.ino()) != directory.identity {
+            return Err(invalid(
+                "archive directory changed before metadata restoration",
+            ));
+        }
+        metadata
+    };
+    #[cfg(unix)]
+    if preserve_permissions {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(
+            &directory.path,
+            fs::Permissions::from_mode(directory.mode & 0o7777),
+        )?;
+    }
+    if preserve_mtime {
+        let time = filetime::FileTime::from_unix_time(directory.mtime, 0);
+        #[cfg(unix)]
+        {
+            // Restore time without reopening a directory whose archived mode
+            // can remove all access. The captured identity is checked after
+            // callbacks; concurrent tree mutation remains outside the contract.
+            filetime::set_symlink_file_times(
+                &directory.path,
+                filetime::FileTime::from_last_access_time(&metadata),
+                time,
+            )?;
+        }
+        #[cfg(not(unix))]
+        filetime::set_file_mtime(&directory.path, time)?;
     }
     Ok(())
 }

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -271,6 +271,15 @@ pub(super) fn unpack_archive<R: Read>(
             &output,
             opts.overwrite,
         )?;
+        if entry.kind == EntryType::File
+            && entry.sparse.is_some()
+            && entry.logical_size > i64::MAX as u64
+            && (opts.overwrite || fs::symlink_metadata(&output).is_err())
+        {
+            return Err(invalid(
+                "sparse output length exceeds the filesystem offset range",
+            ));
+        }
         ensure_safe_parents(&root, &relative)?;
         match entry.kind {
             EntryType::Directory => {
@@ -464,6 +473,15 @@ pub(super) fn unpack_entry<R: Read>(
         &output,
         opts.overwrite,
     )?;
+    if entry.kind == EntryType::File
+        && entry.sparse.is_some()
+        && entry.logical_size > i64::MAX as u64
+        && (opts.overwrite || fs::symlink_metadata(&output).is_err())
+    {
+        return Err(invalid(
+            "sparse output length exceeds the filesystem offset range",
+        ));
+    }
     ensure_safe_parents(root, &relative)?;
     match entry.kind {
         EntryType::Directory => {

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -1,5 +1,5 @@
 use super::format::path_requires_directory;
-use super::{Archive, Entry, EntryType, Result, invalid};
+use super::{Archive, Entry, EntryType, Result, error, invalid};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
 use std::path::{Component, Path, PathBuf};
@@ -143,7 +143,7 @@ impl<'a> EntryUnpacker<'a> {
     ///
     /// Returns an error for an unsafe path, malformed link target, truncated
     /// data, callback-independent I/O failure, or filesystem extraction
-    /// failure.
+    /// failure, or if the entry is stale, already read, or previously extracted.
     pub fn unpack<R: Read>(&mut self, entry: &mut Entry<R>) -> Result<UnpackSummary> {
         unpack_entry(entry, &self.root, self.opts, &mut self.deferred_dirs)
     }
@@ -369,6 +369,18 @@ pub(super) fn unpack_entry<R: Read>(
     opts: &mut UnpackOptions,
     deferred_dirs: &mut Vec<(PathBuf, u32, i64)>,
 ) -> Result<UnpackSummary> {
+    if entry.generation != entry.state.borrow().generation {
+        return Err(error(
+            ErrorKind::InvalidInput,
+            "entry is stale because iteration advanced",
+        ));
+    }
+    if entry.logical_pos != 0 || entry.extraction_started {
+        return Err(error(
+            ErrorKind::InvalidInput,
+            "entry was already read or extraction was started",
+        ));
+    }
     validate_directory_suffixes(entry)?;
     let original = entry.path()?.into_owned();
     if let Some(callback) = opts.on_entry.as_mut() {
@@ -416,6 +428,7 @@ pub(super) fn unpack_entry<R: Read>(
             if output.exists() && fs::symlink_metadata(&output)?.file_type().is_symlink() {
                 return Err(invalid("archive directory collides with symlink"));
             }
+            entry.extraction_started = true;
             fs::create_dir_all(&output)?;
             deferred_dirs.push((output, entry.header.mode, entry.header.mtime));
             summary.dirs = 1;
@@ -428,6 +441,9 @@ pub(super) fn unpack_entry<R: Read>(
                 });
                 return Ok(summary);
             }
+            // Sparse copying and zero-sized entries do not advance logical_pos.
+            // Once output preparation succeeds, even a failed copy is consumed.
+            entry.extraction_started = true;
             let mut file = OpenOptions::new()
                 .write(true)
                 .create_new(true)
@@ -463,6 +479,7 @@ pub(super) fn unpack_entry<R: Read>(
                 });
                 return Ok(summary);
             }
+            entry.extraction_started = true;
             let target = entry
                 .header
                 .link_name()
@@ -492,6 +509,7 @@ pub(super) fn unpack_entry<R: Read>(
                 });
                 return Ok(summary);
             }
+            entry.extraction_started = true;
             let target = entry
                 .header
                 .link_name()

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -237,6 +237,16 @@ pub(super) fn unpack_archive<R: Read>(
             });
             continue;
         }
+        if matches!(
+            entry.kind,
+            EntryType::CharDevice | EntryType::BlockDevice | EntryType::Fifo
+        ) {
+            summary.skipped.push(SkippedEntry {
+                path: original,
+                reason: SkipReason::UnsupportedType,
+            });
+            continue;
+        }
         let output = root.join(&relative);
         ensure_safe_parents(&root, &relative)?;
         match entry.kind {
@@ -383,6 +393,16 @@ pub(super) fn unpack_entry<R: Read>(
         summary.skipped.push(SkippedEntry {
             path: original,
             reason: SkipReason::ReservedName,
+        });
+        return Ok(summary);
+    }
+    if matches!(
+        entry.kind,
+        EntryType::CharDevice | EntryType::BlockDevice | EntryType::Fifo
+    ) {
+        summary.skipped.push(SkippedEntry {
+            path: original,
+            reason: SkipReason::UnsupportedType,
         });
         return Ok(summary);
     }

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -245,7 +245,7 @@ pub(super) fn unpack_archive<R: Read>(
             continue;
         }
         let output = root.join(&relative);
-        if entry.kind == EntryType::Hardlink
+        if matches!(entry.kind, EntryType::Hardlink | EntryType::Symlink)
             && skip_existing_output(&root, &relative, opts.overwrite)?
         {
             summary.skipped.push(SkippedEntry {
@@ -314,19 +314,21 @@ pub(super) fn unpack_archive<R: Read>(
                 summary.files += 1;
             }
             EntryType::Symlink => {
-                if !prepare_output(&output, opts.overwrite)? {
-                    summary.skipped.push(SkippedEntry {
-                        path: original,
-                        reason: SkipReason::Exists,
-                    });
-                    continue;
-                }
                 let target = entry
                     .header
                     .link_name()
                     .ok_or_else(|| invalid("symlink lacks target"))?;
-                match create_symlink(&target, &output) {
-                    Ok(()) => summary.symlinks += 1,
+                match replace_output_with_link(&output, opts.overwrite, |path| {
+                    create_symlink(&target, path)
+                }) {
+                    Ok(true) => summary.symlinks += 1,
+                    Ok(false) => {
+                        summary.skipped.push(SkippedEntry {
+                            path: original,
+                            reason: SkipReason::Exists,
+                        });
+                        continue;
+                    }
                     Err(err)
                         if cfg!(windows)
                             && matches!(
@@ -343,17 +345,18 @@ pub(super) fn unpack_archive<R: Read>(
                 }
             }
             EntryType::Hardlink => {
-                if !prepare_output(&output, opts.overwrite)? {
+                let source = hardlink_source
+                    .as_ref()
+                    .ok_or_else(|| invalid("hardlink source was not prepared"))?;
+                if !replace_output_with_link(&output, opts.overwrite, |path| {
+                    fs::hard_link(source, path)
+                })? {
                     summary.skipped.push(SkippedEntry {
                         path: original,
                         reason: SkipReason::Exists,
                     });
                     continue;
                 }
-                let source = hardlink_source
-                    .as_ref()
-                    .ok_or_else(|| invalid("hardlink source was not prepared"))?;
-                fs::hard_link(source, output)?;
                 summary.hardlinks += 1;
             }
             _ => summary.skipped.push(SkippedEntry {
@@ -428,7 +431,9 @@ pub(super) fn unpack_entry<R: Read>(
         return Ok(summary);
     }
     let output = root.join(&relative);
-    if entry.kind == EntryType::Hardlink && skip_existing_output(root, &relative, opts.overwrite)? {
+    if matches!(entry.kind, EntryType::Hardlink | EntryType::Symlink)
+        && skip_existing_output(root, &relative, opts.overwrite)?
+    {
         summary.skipped.push(SkippedEntry {
             path: original,
             reason: SkipReason::Exists,
@@ -499,20 +504,24 @@ pub(super) fn unpack_entry<R: Read>(
             summary.files = 1;
         }
         EntryType::Symlink => {
-            if !prepare_output(&output, opts.overwrite)? {
-                summary.skipped.push(SkippedEntry {
-                    path: original,
-                    reason: SkipReason::Exists,
-                });
-                return Ok(summary);
-            }
-            entry.extraction_started = true;
             let target = entry
                 .header
                 .link_name()
                 .ok_or_else(|| invalid("symlink lacks target"))?;
-            match create_symlink(&target, &output) {
-                Ok(()) => summary.symlinks = 1,
+            match replace_output_with_link(&output, opts.overwrite, |path| {
+                create_symlink(&target, path)
+            }) {
+                Ok(true) => {
+                    entry.extraction_started = true;
+                    summary.symlinks = 1;
+                }
+                Ok(false) => {
+                    summary.skipped.push(SkippedEntry {
+                        path: original,
+                        reason: SkipReason::Exists,
+                    });
+                    return Ok(summary);
+                }
                 Err(err)
                     if cfg!(windows)
                         && matches!(
@@ -529,7 +538,12 @@ pub(super) fn unpack_entry<R: Read>(
             }
         }
         EntryType::Hardlink => {
-            if !prepare_output(&output, opts.overwrite)? {
+            let source = hardlink_source
+                .as_ref()
+                .ok_or_else(|| invalid("hardlink source was not prepared"))?;
+            if !replace_output_with_link(&output, opts.overwrite, |path| {
+                fs::hard_link(source, path)
+            })? {
                 summary.skipped.push(SkippedEntry {
                     path: original,
                     reason: SkipReason::Exists,
@@ -537,10 +551,6 @@ pub(super) fn unpack_entry<R: Read>(
                 return Ok(summary);
             }
             entry.extraction_started = true;
-            let source = hardlink_source
-                .as_ref()
-                .ok_or_else(|| invalid("hardlink source was not prepared"))?;
-            fs::hard_link(source, output)?;
             summary.hardlinks = 1;
         }
         _ => summary.skipped.push(SkippedEntry {
@@ -655,6 +665,59 @@ fn preflight_hardlink_source<R: Read>(
         Err(err) => return Err(err),
     }
     Ok(source)
+}
+
+struct TemporaryLink(PathBuf);
+
+impl Drop for TemporaryLink {
+    fn drop(&mut self) {
+        // A successful rename normally removes this name. It can also be a
+        // no-op when both names already refer to the same hard-linked inode.
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+fn replace_output_with_link(
+    path: &Path,
+    overwrite: bool,
+    create: impl Fn(&Path) -> Result<()>,
+) -> Result<bool> {
+    static NEXT_LINK: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    match fs::symlink_metadata(path) {
+        Ok(_) if !overwrite => return Ok(false),
+        Ok(metadata) if metadata.is_dir() => {
+            return Err(invalid("archive file collides with existing directory"));
+        }
+        Ok(_) => {}
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            create(path)?;
+            return Ok(true);
+        }
+        Err(err) => return Err(err),
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid("link output has no parent directory"))?;
+    for _ in 0..128 {
+        let id = NEXT_LINK.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let temporary = parent.join(format!(".jdx-tar-{}-{id}.link", std::process::id()));
+        match create(&temporary) {
+            Ok(()) => {
+                let temporary = TemporaryLink(temporary);
+                // The destination is untouched until the OS has accepted the
+                // replacement link; a sibling rename commits the change.
+                fs::rename(&temporary.0, path)?;
+                return Ok(true);
+            }
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Err(std::io::Error::new(
+        ErrorKind::AlreadyExists,
+        "unable to reserve a temporary link name",
+    ))
 }
 
 fn skip_existing_output(root: &Path, relative: &Path, overwrite: bool) -> Result<bool> {

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -248,7 +248,7 @@ pub(super) fn unpack_archive<R: Read>(
                 deferred_dirs.push((output, entry.header.mode, entry.header.mtime));
                 summary.dirs += 1;
             }
-            EntryType::File => {
+            EntryType::File | EntryType::Other(_) => {
                 if !prepare_output(&output, opts.overwrite)? {
                     summary.skipped.push(SkippedEntry {
                         path: original,
@@ -397,7 +397,7 @@ pub(super) fn unpack_entry<R: Read>(
             deferred_dirs.push((output, entry.header.mode, entry.header.mtime));
             summary.dirs = 1;
         }
-        EntryType::File => {
+        EntryType::File | EntryType::Other(_) => {
             if !prepare_output(&output, opts.overwrite)? {
                 summary.skipped.push(SkippedEntry {
                     path: original,

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -155,16 +155,11 @@ impl<'a> EntryUnpacker<'a> {
     /// Returns an error when directory permissions or modification times
     /// cannot be restored.
     pub fn finish(self) -> Result<()> {
-        for (path, mode, mtime) in self.deferred_dirs.into_iter().rev() {
-            apply_metadata(
-                &path,
-                mode,
-                mtime,
-                self.opts.preserve_permissions,
-                self.opts.preserve_mtime,
-            )?;
-        }
-        Ok(())
+        apply_deferred_directory_metadata(
+            self.deferred_dirs,
+            self.opts.preserve_permissions,
+            self.opts.preserve_mtime,
+        )
     }
 }
 
@@ -257,7 +252,11 @@ pub(super) fn unpack_archive<R: Read>(
                     return Err(invalid("archive directory collides with symlink"));
                 }
                 fs::create_dir_all(&output)?;
-                deferred_dirs.push((output, entry.header.mode, entry.header.mtime));
+                deferred_dirs.push((
+                    fs::canonicalize(output)?,
+                    entry.header.mode,
+                    entry.header.mtime,
+                ));
                 summary.dirs += 1;
             }
             EntryType::File | EntryType::Other(_) => {
@@ -355,9 +354,7 @@ pub(super) fn unpack_archive<R: Read>(
         }
         progress.boundary(entry.bytes_read());
     }
-    for (path, mode, mtime) in deferred_dirs.into_iter().rev() {
-        apply_metadata(&path, mode, mtime, preserve_permissions, preserve_mtime)?;
-    }
+    apply_deferred_directory_metadata(deferred_dirs, preserve_permissions, preserve_mtime)?;
     progress.boundary(archive.state.borrow().raw_bytes);
     Ok(summary)
 }
@@ -430,7 +427,11 @@ pub(super) fn unpack_entry<R: Read>(
             }
             entry.extraction_started = true;
             fs::create_dir_all(&output)?;
-            deferred_dirs.push((output, entry.header.mode, entry.header.mtime));
+            deferred_dirs.push((
+                fs::canonicalize(output)?,
+                entry.header.mode,
+                entry.header.mtime,
+            ));
             summary.dirs = 1;
         }
         EntryType::File | EntryType::Other(_) => {
@@ -608,6 +609,25 @@ fn prepare_output(path: &Path, overwrite: bool) -> Result<bool> {
         Err(err) if err.kind() == ErrorKind::NotFound => Ok(true),
         Err(err) => Err(err),
     }
+}
+
+fn apply_deferred_directory_metadata(
+    directories: Vec<(PathBuf, u32, i64)>,
+    preserve_permissions: bool,
+    preserve_mtime: bool,
+) -> Result<()> {
+    // Canonical paths coalesce case and Unicode aliases on filesystems that
+    // resolve those spellings to the same directory. The last member wins.
+    let mut latest = std::collections::BTreeMap::new();
+    for (path, mode, mtime) in directories {
+        latest.insert(path, (mode, mtime));
+    }
+    let mut directories: Vec<_> = latest.into_iter().collect();
+    directories.sort_by_key(|(path, _)| std::cmp::Reverse(path.components().count()));
+    for (path, (mode, mtime)) in directories {
+        apply_metadata(&path, mode, mtime, preserve_permissions, preserve_mtime)?;
+    }
+    Ok(())
 }
 
 fn apply_metadata(

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -264,6 +264,13 @@ pub(super) fn unpack_archive<R: Read>(
         } else {
             None
         };
+        validate_mtime_before_output(
+            entry.kind,
+            entry.header.mtime,
+            opts.preserve_mtime,
+            &output,
+            opts.overwrite,
+        )?;
         ensure_safe_parents(&root, &relative)?;
         match entry.kind {
             EntryType::Directory => {
@@ -450,6 +457,13 @@ pub(super) fn unpack_entry<R: Read>(
     } else {
         None
     };
+    validate_mtime_before_output(
+        entry.kind,
+        entry.header.mtime,
+        opts.preserve_mtime,
+        &output,
+        opts.overwrite,
+    )?;
     ensure_safe_parents(root, &relative)?;
     match entry.kind {
         EntryType::Directory => {
@@ -841,6 +855,25 @@ fn is_reserved_path(path: &Path) -> bool {
 #[cfg(not(windows))]
 fn is_reserved_path(_path: &Path) -> bool {
     false
+}
+
+fn validate_mtime_before_output(
+    kind: EntryType,
+    mtime: i64,
+    preserve_mtime: bool,
+    output: &Path,
+    overwrite: bool,
+) -> Result<()> {
+    let skips_existing_file =
+        kind == EntryType::File && !overwrite && fs::symlink_metadata(output).is_ok();
+    if preserve_mtime
+        && matches!(kind, EntryType::File | EntryType::Directory)
+        && mtime == i64::MIN
+        && !skips_existing_file
+    {
+        return Err(invalid("tar mtime is too small to restore safely"));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -1,3 +1,4 @@
+use super::format::path_requires_directory;
 use super::{Archive, Entry, EntryType, Result, invalid};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
@@ -213,6 +214,7 @@ pub(super) fn unpack_archive<R: Read>(
     let mut entries = archive.entries()?;
     for item in &mut entries {
         let mut entry = item?;
+        validate_directory_suffixes(&entry)?;
         let original = entry.path()?.into_owned();
         if let Some(callback) = opts.on_entry.as_mut() {
             callback(&EntryInfo {
@@ -367,6 +369,7 @@ pub(super) fn unpack_entry<R: Read>(
     opts: &mut UnpackOptions,
     deferred_dirs: &mut Vec<(PathBuf, u32, i64)>,
 ) -> Result<UnpackSummary> {
+    validate_directory_suffixes(entry)?;
     let original = entry.path()?.into_owned();
     if let Some(callback) = opts.on_entry.as_mut() {
         callback(&EntryInfo {
@@ -512,6 +515,24 @@ pub(super) fn unpack_entry<R: Read>(
     }
     progress.boundary(entry.bytes_read());
     Ok(summary)
+}
+
+fn validate_directory_suffixes<R: Read>(entry: &Entry<R>) -> Result<()> {
+    if entry.kind != EntryType::Directory && path_requires_directory(&entry.header.path) {
+        return Err(invalid(
+            "only a directory may have a directory-required path suffix",
+        ));
+    }
+    if entry.kind == EntryType::Hardlink
+        && entry
+            .header
+            .link_name
+            .as_deref()
+            .is_some_and(path_requires_directory)
+    {
+        return Err(invalid("hardlink target requires a directory"));
+    }
+    Ok(())
 }
 
 fn secure_relative_path(path: &Path, strip: usize) -> Result<Option<PathBuf>> {


### PR DESCRIPTION
## Summary
- harden TAR header, PAX, GNU sparse, and effective-name parsing against ambiguous or malformed representations
- preflight extraction mutations so invalid links, sparse lengths, timestamps, and metadata targets cannot destructively fail after replacing output
- bound pending metadata work and preserve archive iteration, callback-root, and selected-entry lifecycle invariants
- preflight writer entries before emitting stateful or unrepresentable output

The imported fix commits preserve authorship by @zanieb. The integration-resolution commit also includes Zanie Blue as a co-author.

## Validation
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- all 35 supplied finding branches pass their regression suites independently
- compatible supplied regression suites pass against the combined source; two overwrite-disabled invalid-link expectations are intentionally superseded by earlier reader-side rejection of invalid effective link targets
- mise compiles with all features against the patched crate via a local Cargo patch

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes sit on security-critical tar parsing and filesystem extraction paths (path validation, links, sparse files, metadata), where bugs could enable traversal or destructive partial writes despite added guards.
> 
> **Overview**
> Tightens **read**, **write**, and **unpack** behavior so malformed or ambiguous tar data is rejected earlier and extraction cannot partially commit unsafe state.
> 
> **Reader (`lib.rs` / `format.rs`):** Stricter checks on extension carriers (PAX, GNU long names), zero-block termination, conflicting path/link metadata, empty or NUL paths, non-regular entries with payload, and GNU sparse/PAX combinations. Global PAX is layered and bounded; iteration cannot restart after bytes are consumed; entries go stale if iteration advances. Numeric parsing and PAX application (mtime, linkpath, sparse maps) are more conservative.
> 
> **Writer (`builder.rs`):** `append_data` / `append_link` validate names, directory suffix rules, and entry types before writing; caller headers update only on success. Header fields can use **base-256** for large values and **signed** mtimes.
> 
> **Unpack (`unpack.rs`):** Preflights hardlinks, directory-only path suffixes, extreme mtimes, and oversized sparse outputs before mutating disk. Tracks extraction-root identity across callbacks/progress; symlink/hardlink overwrites use a temp-then-rename path; deferred directory metadata is deduped and verified by inode before restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da88dfc10676a1e59dc94ed1f9e1e109bbc456d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive validation for invalid paths, link targets, malformed metadata, unsupported entries, and conflicting file information.
  * Prevented unsafe extraction scenarios, including destination changes, stale entries, unsafe hard links, and partial output replacement.
  * Improved handling of sparse files, extended metadata, timestamps, and large numeric values.
  * Extraction and progress errors are now reported more reliably.

* **Compatibility**
  * Added support for negative timestamps and larger header values.
  * Improved preservation and resolution of layered archive metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->